### PR TITLE
Add experimental language servers

### DIFF
--- a/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -37,6 +37,12 @@ spec:
         - -addr=:4388
         env:
 {{ include "envVars" $envVars | trimSuffix "\n" | indent 8 }}
+{{- range $langserver := .Values.site.langservers }}
+{{- if not (has $langserver.language (list "go" "java" "php" "python" "javascript" "typescript")) }}
+        - name: LANGSERVER_{{ $langserver.language | upper }}
+          value: tcp://xlang-{{ default $langserver.language }}:8080
+{{- end }}
+{{- end }}
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: SRC_PROF_HTTP

--- a/templates/xlang/experimental.yaml
+++ b/templates/xlang/experimental.yaml
@@ -1,0 +1,64 @@
+
+{{- range $index, $langserver := .Values.site.langservers -}}
+
+{{- if not (has $langserver.language (list "go" "java" "php" "python" "javascript" "typescript")) }}
+
+{{- if eq $index 0 | not }}
+---
+{{ end -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: xlang-{{ $langserver.language }}
+  name: xlang-{{ $langserver.language }}
+spec:
+  ports:
+  - name: lsp
+    port: 8080
+    targetPort: lsp
+  selector:
+    app: xlang-{{ $langserver.language }}
+  type: ClusterIP
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    description: LSP server for {{ $langserver.language }} (used for live requests).
+  name: xlang-{{ $langserver.language }}
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: xlang-{{ $langserver.language }}
+    spec:
+      containers:
+      - image: sourcegraph/codeintel-{{ default $langserver.language (index (dict "cs" "csharp" "dockerfile" "docker") $langserver.language) }}
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: lsp
+          timeoutSeconds: 5
+        name: xlang-{{ $langserver.language }}
+        ports:
+        - containerPort: 8080
+          name: lsp
+        readinessProbe:
+          tcpSocket:
+            port: lsp
+
+{{- end }}
+
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -231,6 +231,49 @@ site: {
     # {
     #   "language": "php",
     # },
+
+    # WARNING experimental language servers follow - read about the caveats
+    # before enabling them:
+    # https://about.sourcegraph.com/docs/code-intelligence/experimental-language-servers#caveats-of-experimental-language-servers
+    # {
+    #   "language": "bash",
+    # },
+    # {
+    #   "language": "clojure",
+    # },
+    # {
+    #   "language": "cpp",
+    # },
+    # {
+    #   "language": "cs",
+    # },
+    # {
+    #   "language": "css",
+    # },
+    # {
+    #   "language": "dockerfile",
+    # },
+    # {
+    #   "language": "elixir",
+    # },
+    # {
+    #   "language": "html",
+    # },
+    # {
+    #   "language": "lua",
+    # },
+    # {
+    #   "language": "ocaml",
+    # },
+    # {
+    #   "language": "r",
+    # },
+    # {
+    #   "language": "ruby",
+    # },
+    # {
+    #   "language": "rust",
+    # },
   ],
 
   # RBAC is enabled by default. Some Kubernetes environments do not permit RBAC. Set to "disabled" to disable and prevent RBAC objects from being generated.


### PR DESCRIPTION
This uses templating functions to range over the `langservers` in the site configuration. That means that all the user has to do is add entries to `langservers` (e.g. `{ "language": "rust" }`) and the Data Center installation will be spun up with the corresponding container.

TODO

- [x] Use ranges and variable references in the templating language to eliminate some of the redundancy
- [x] Add all the `Service`s and `Deployment`s (the ones for our non-experimental language servers live under `templates/xlang/<name>`, but we can probably range over the names and fill them in with templating)