### PR TITLE
indexed-search: Add migration env var

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - /data/index
         - -pprof
         - -rpc
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-webserver
         ports:
         - containerPort: 6070
@@ -61,7 +61,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
-        image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+        env:
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
+        image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
         name: zoekt-indexserver
         ports:
         - containerPort: 6072

--- a/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/templates/indexed-search/indexed-search.Deployment.yaml
@@ -53,6 +53,10 @@ spec:
         - 1m
         - -cpu_fraction
         - "1.0"
+        env:
+{{- /* Remove for July 2018 release. https://github.com/sourcegraph/sourcegraph/issues/10775 */}}
+        - name: ZOEKT_DELETE_REPOS_MIGRATION
+          value: t
         image: {{ .Values.const.indexedSearch.image }}
         name: zoekt-indexserver
         ports:

--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ const:
   githubProxy:
     image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
   indexedSearch:
-    image: docker.sourcegraph.com/zoekt:18-05-08_69c0db5
+    image: docker.sourcegraph.com/zoekt:18-05-21_71d89f8
   indexer:
     image: docker.sourcegraph.com/indexer:14412_2018-04-20_fddd20b
   lspProxy:


### PR DESCRIPTION
We also bump the container to use to include the migration.

Part of https://github.com/sourcegraph/sourcegraph/issues/10775