### PR TITLE
ci: Specify namespace in generate-examples

### DIFF
--- a/examples/generate-examples.sh
+++ b/examples/generate-examples.sh
@@ -8,7 +8,7 @@ function generate() {
     example="$1"
     rm -rf "${example}/generated"
     mkdir -p "${example}/generated"
-    helm template -f "${example}/values.yaml" ../ --output-dir "${example}/generated"
+    helm template --namespace default -f "${example}/values.yaml" ../ --output-dir "${example}/generated"
 }
 
 if [ -z "$EXAMPLE" ]; then


### PR DESCRIPTION
Buildkite is now running in a different namespace. It seems helm by default
uses the current namespace, which I assume it gets from the default service
account. As such this was leading to CI failing since the example templates
would have the NS set to "buildkite".