### PR TITLE
indexed-search: Double CPU limit for indexserver

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           name: index-http
         resources:
           limits:
-            cpu: "2"
+            cpu: "4"
             memory: "4G"
           requests:
             cpu: "500m"

--- a/values.yaml
+++ b/values.yaml
@@ -79,9 +79,11 @@ cluster:
           memory: 1G
   indexedSearch:
     containers:
+      # zoekt-indexserver is CPU bound. The more CPU you allocate to it, the
+      # lower lag between a new commit and it being indexed for search.
       zoekt-indexserver:
         limits:
-          cpu: "2"
+          cpu: "4"
           memory: 4G
         requests:
           cpu: "500m"


### PR DESCRIPTION
zoekt-indexserver is CPU bound. We have observed index times for large monorepos
go from 6 minutes to 3 minutes by increasing the number of cores from 2 to 4.