### PR TITLE
update xlang-go image version

### DIFF
--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:15184_2018-05-10_31c2921
+        image: docker.sourcegraph.com/xlang-go:16161_2018-05-30_21033f1
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:15184_2018-05-10_31c2921
+        image: docker.sourcegraph.com/xlang-go:16161_2018-05-30_21033f1
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ const:
   syntectServer:
     image: docker.sourcegraph.com/syntect_server:d4be6b90
   xlangGo:
-    image: docker.sourcegraph.com/xlang-go:15184_2018-05-10_31c2921
+    image: docker.sourcegraph.com/xlang-go:16161_2018-05-30_21033f1
   xlangJava:
     image: docker.sourcegraph.com/xlang-java-skinny:2018-05-10-1621
   xlangJavascriptTypescript:


### PR DESCRIPTION
This updates the xlang-go image version to include a fix for the Go
language server returning poor error messages `invalid location` for
unsupported CGO files rather than a more legible `File $FILE is ignored by the build.`
error.

See https://github.com/sourcegraph/issues/issues/59