### PR TITLE
pin experimental language server image versions

### DIFF
--- a/templates/xlang/experimental.yaml
+++ b/templates/xlang/experimental.yaml
@@ -1,7 +1,8 @@
 
+{{- $experimentalLangServers := .Values.const.experimentalLangServers -}}
 {{- range $index, $langserver := .Values.site.langservers -}}
 
-{{- if not (has $langserver.language (list "go" "java" "php" "python" "javascript" "typescript")) }}
+{{- if (hasKey $experimentalLangServers $langserver.language) -}}
 
 {{- if eq $index 0 | not }}
 ---
@@ -45,7 +46,8 @@ spec:
         app: xlang-{{ $langserver.language }}
     spec:
       containers:
-      - image: sourcegraph/codeintel-{{ default $langserver.language (index (dict "cs" "csharp" "dockerfile" "docker") $langserver.language) }}
+      {{ $imageName := (pluck "image" (pluck $langserver.language $experimentalLangServers | first) | first) -}}
+      - image: {{ $imageName }}
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,33 @@ const:
     image: docker.sourcegraph.com/xlang-python:13187_2018-03-22_b2b49c2
   xlangPHP:
     image: docker.sourcegraph.com/xlang-php:00024_2018-05-16_beca197
+  experimentalLangServers:
+    bash:
+      image: sourcegraph/codeintel-bash:00239_2018-05-31_6b6cac4
+    clojure:
+      image: sourcegraph/codeintel-clojure:00231_2018-05-31_eef495b
+    cpp:
+      image: sourcegraph/codeintel-cpp:00239_2018-05-31_6b6cac4
+    cs:
+      image: sourcegraph/codeintel-csharp:00225_2018-05-26_26f55a3
+    css:
+      image: sourcegraph/codeintel-css:00239_2018-05-31_6b6cac4
+    dockerfile:
+      image: sourcegraph/codeintel-docker:00239_2018-05-31_6b6cac4
+    elixir:
+      image: sourcegraph/codeintel-elixir:00239_2018-05-31_6b6cac4
+    html:
+      image: sourcegraph/codeintel-html:00239_2018-05-31_6b6cac4
+    lua:
+      image: sourcegraph/codeintel-lua:00225_2018-05-26_26f55a3
+    ocaml:
+      image: sourcegraph/codeintel-ocaml:00239_2018-05-31_6b6cac4
+    r:
+      image: sourcegraph/codeintel-r:00239_2018-05-31_6b6cac4
+    ruby:
+      image: sourcegraph/codeintel-ruby:00239_2018-05-31_6b6cac4
+    rust:
+      image: sourcegraph/codeintel-rust00239_2018-05-31_6b6cac4
 
 # cluster specifies the Docker images to use for each service along with replica counts and resource specs where they
 # are tunable.


### PR DESCRIPTION
We now specify specific versions for each experimental language server, instead of just using the "latest" tag (which along with our default `imagePullPolicy` would prevent new versions from being pulled after the first pull).

I avoided specifying new files for each new language sever because copy-pasting the same configuration values for each new language seemed like a bad idea. Instead, I added a new `experimentalLangServers` dict to the `const` field in the values file. The key in the dict is the colloquial name for the experimental language (same as site configuration, and the image field points to the specific image on dockerhub to pull. 