### PR TITLE
bump lsp-proxy version tag

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+        image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/values.yaml
+++ b/values.yaml
@@ -20,7 +20,7 @@ const:
   indexer:
     image: docker.sourcegraph.com/indexer:15336_2018-05-14_cec0d98
   lspProxy:
-    image: docker.sourcegraph.com/lsp-proxy:14260_2018-04-16_be94954
+    image: docker.sourcegraph.com/lsp-proxy:16321_2018-06-01_297e2ff
   queryRunner:
     image: docker.sourcegraph.com/query-runner:14411_2018-04-20_fddd20b
   repoUpdater:


### PR DESCRIPTION
This new version of lsp-proxy includes an increase to the amount of time that lsp-proxy will wait for a language server to initialize before timing out the request, and a better error message for when the timeout occurs. 