### PR TITLE
Respect the langservers.address field

### DIFF
--- a/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,10 +38,10 @@ spec:
         env:
 {{ include "envVars" $envVars | trimSuffix "\n" | indent 8 }}
 {{- range $langserver := .Values.site.langservers }}
-{{- if not (has $langserver.language (list "go" "java" "php" "python" "javascript" "typescript")) }}
+  {{- if not (has $langserver.language (list "go" "java" "php" "python" "javascript" "typescript")) }}
         - name: LANGSERVER_{{ $langserver.language | upper }}
-          value: tcp://xlang-{{ default $langserver.language }}:8080
-{{- end }}
+          value: {{ $langserver.address | default (join "" (list "tcp://xlang-" $langserver.language ":8080")) }}
+  {{- end }}
 {{- end }}
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379


### PR DESCRIPTION
Previously, setting `langservers.address` had no effect because your setting would be ignored by the helm templating logic (my fault 😞 ).

This fixes the logic so that your address is respected.

@beyang This is a requirement for merging in the config changes for experimental language servers into https://github.com/sourcegraph/infrastructure Once this is merged in, do we need to tag the commit for a release so that this fix gets picked up by https://github.com/sourcegraph/infrastructure ?