### PR TITLE
Add tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,3 +3,5 @@ steps:
     command: .buildkite/verify-generated.sh
   - label: ":k8s:"
     command: .buildkite/verify-valid.sh
+  - label: "tests"
+    command: curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python2.7 get-pip.py && pip install yq && ./test

--- a/test
+++ b/test
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+assertInstalled() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if ! assertInstalled helm || ! assertInstalled yq; then
+  echo "You need to install dependencies: brew install helm yq"
+  exit 1
+fi
+
+assertStdin() {
+  cat > stdin
+  if ! [ "$(cat stdin)" = "$1" ]; then
+    rm stdin
+    echo
+    echo "$2"
+    echo "- Expected $1 but got $(cat stdin)"
+    exit 1
+  fi
+  rm stdin
+}
+
+helm template . \
+  --set cluster.storageClass.create=none \
+  --set site.langservers[0].language=html \
+  | yq "select(.kind == \"Deployment\" and .metadata.name == \"lsp-proxy\")" \
+  | yq ".spec.template.spec.containers[0].env | any(. == {name:\"LANGSERVER_HTML\", value:\"tcp://xlang-html:8080\"})" \
+  | assertStdin "true" "Specifying an experimental language server should set an environment variable on lsp-proxy."
+
+helm template . \
+  --set cluster.storageClass.create=none \
+  --set site.langservers[0].language=html \
+  --set site.langservers[0].address=tcp://1.2.3.4:1234 \
+  | yq "select(.kind == \"Deployment\" and .metadata.name == \"lsp-proxy\")" \
+  | yq ".spec.template.spec.containers[0].env | any(. == {name:\"LANGSERVER_HTML\", value:\"tcp://1.2.3.4:1234\"})" \
+  | assertStdin "true" "langservers[].address should be respected."
+
+echo "All tests passed."


### PR DESCRIPTION
I was a bit afraid to make a change to the language server templating logic because there weren't any tests.

Here's the anatomy of a test:

```bash
# Call `helm template` to dump YAML to stdout
helm template . \
  # This is currently a required parameter for all deployments
  --set cluster.storageClass.create=none \
  # Set some values (just like you'd do in values.yaml)
  --set site.langservers[0].language=html \
  --set site.langservers[0].address=tcp://1.2.3.4:1234 \
  # Pipe the stdout to yq (YAML equivalent of jq)
  # Every object would be a YAML file in the templates/ directory
  # This filters to only the deployment named lsp-proxy
  | yq "select(.kind == \"Deployment\" and .metadata.name == \"lsp-proxy\")" \
  # This does some test-specific check
  | yq ".spec.template.spec.containers[0].env | any(. == {name:\"LANGSERVER_HTML\", value:\"tcp://1.2.3.4:1234\"})" \
  # Here the expected result is "true" and the test is given a name
  | assertStdin "true" "langservers[].address should be respected."
```

Bash is a bit clunky, but at least it's something.