### PR TITLE
bump repo-updater

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+        image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ const:
   queryRunner:
     image: docker.sourcegraph.com/query-runner:14411_2018-04-20_fddd20b
   repoUpdater:
-    image: docker.sourcegraph.com/repo-updater:14230_2018-04-13_770f492
+    image: docker.sourcegraph.com/repo-updater:16477_2018-06-05_e786c66
   pgsql:
     exporterImage: docker.sourcegraph.com/pgsql-exporter:a294a9b6d83c139d3e1217f02c8f80a54cbf73ac
     image: docker.sourcegraph.com/postgres:9.4


### PR DESCRIPTION
a recent change to the gitserver client affected frontend and repo-updater.

note: it also affected frontend, i think, but i don't know the magic for updating deploy-sourcegraph, or whether magic is needed? sending this to get the buildkite test and because readme.dev.md says so.