### PR TITLE
release new syntect_server version + bump frontend version

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -74,7 +74,7 @@ spec:
           value: val
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -72,7 +72,7 @@ spec:
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+        image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@
 # const defines configuration constants that generally should not be changed unless testing out experimental or pre-release features.
 const:
   frontend:
-    image: docker.sourcegraph.com/frontend:16491_2018-06-05_b9f9e8a
+    image: docker.sourcegraph.com/frontend:16693_2018-06-09_7fcd649
   searcher:
     image: docker.sourcegraph.com/searcher:15826_2018-05-21_b86d51e
   symbols:

--- a/values.yaml
+++ b/values.yaml
@@ -29,7 +29,7 @@ const:
     exporterImage: docker.sourcegraph.com/pgsql-exporter:a294a9b6d83c139d3e1217f02c8f80a54cbf73ac
     image: docker.sourcegraph.com/postgres:9.4
   syntectServer:
-    image: docker.sourcegraph.com/syntect_server:d4be6b90
+    image: docker.sourcegraph.com/syntect_server:624a1a2
   xlangGo:
     image: docker.sourcegraph.com/xlang-go:16161_2018-05-30_21033f1
   xlangJava:


### PR DESCRIPTION
This updates the syntect_server version to the latest which includes lots of goodies. Additionally, in order to do so, we must bump the frontend version to at least this version.

I will merge right now so this will be in the next release.

Note: The frontend is backwards-compatible with the old syntect_server version for now, but frontend versions older than the one specified here are not forwards-compatible with the new syntect_server version. 