### PR TITLE
Bump versions to use new redis envvar behaviour

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,8 +56,6 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
@@ -68,7 +64,7 @@ spec:
           value: val
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -114,13 +114,11 @@
 {{- $_ := set .envVars "LSP_PROXY" "lsp-proxy:4388" -}}
 
 {{- $_ := set .envVars "PUBLIC_REPO_REDIRECTS" "\"true\"" -}}
-{{- $_ := set .envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set .envVars "SEARCHER_URL" "k8s+http://searcher:3181" -}}
 {{- $_ := set .envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set .envVars "SRC_INDEXER" "indexer:3179" -}}
 {{- $_ := set .envVars "SRC_LOG_LEVEL" "dbug" -}}
 {{- $_ := set .envVars "SRC_SESSION_COOKIE_KEY" .Values.site.sessionCookieKey -}}
-{{- $_ := set .envVars "SRC_SESSION_STORE_REDIS" "redis-store:6379" -}}
 {{- $_ := set .envVars "SRC_SYNTECT_SERVER" "http://syntect-server:9238" -}}
 {{- $_ := set .envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- $_ := set .envVars "SYMBOLS_URL" "k8s+http://symbols:3184" -}}

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,15 +56,13 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
           value: k8s+http://symbols:3184
         - name: ZOEKT_HOST
           value: indexed-search:80
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE
@@ -58,8 +56,6 @@ spec:
           value: dbug
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: SRC_SESSION_STORE_REDIS
-          value: redis-store:6379
         - name: SRC_SYNTECT_SERVER
           value: http://syntect-server:9238
         - name: SYMBOLS_URL
@@ -78,7 +74,7 @@ spec:
             secretKeyRef:
               key: key
               name: tls
-        image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+        image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@
 # const defines configuration constants that generally should not be changed unless testing out experimental or pre-release features.
 const:
   frontend:
-    image: docker.sourcegraph.com/frontend:17750_2018-06-30_9391756
+    image: docker.sourcegraph.com/frontend:18005_2018-07-09_0bcc142
   searcher:
     image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
   symbols:
@@ -18,20 +18,20 @@ const:
   indexedSearch:
     image: docker.sourcegraph.com/zoekt:18-05-30_3d2275e
   indexer:
-    image: docker.sourcegraph.com/indexer:17095_2018-06-15_786c9d4
+    image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
   lspProxy:
-    image: docker.sourcegraph.com/lsp-proxy:17712_2018-06-29_ba1da53
+    image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
   queryRunner:
     image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
   repoUpdater:
-    image: docker.sourcegraph.com/repo-updater:17098_2018-06-15_786c9d4
+    image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
   pgsql:
     exporterImage: docker.sourcegraph.com/pgsql-exporter:a294a9b6d83c139d3e1217f02c8f80a54cbf73ac
     image: docker.sourcegraph.com/postgres:9.4
   syntectServer:
     image: docker.sourcegraph.com/syntect_server:d4be6b90
   xlangGo:
-    image: docker.sourcegraph.com/xlang-go:17111_2018-06-15_84e1df7
+    image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
   xlangJava:
     image: docker.sourcegraph.com/xlang-java-skinny:2018-05-10-1621
   xlangJavascriptTypescript:


### PR DESCRIPTION
We have switched to use the more consistent `REDIS_CACHE_ENDPOINT` and `REDIS_STORE_ENDPOINT` to specify the addresses of our two redis instances. This PR bumps all the image versions to read the new environment variable. Additionally we remove specifying the environment variables since the defaults work in kubernetes.

Part of https://github.com/sourcegraph/sourcegraph/issues/12221