### PR TITLE
remove QUERY_RUNNER_URL

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -115,7 +115,6 @@
 {{- $_ := set .envVars "LSP_PROXY" "lsp-proxy:4388" -}}
 
 {{- $_ := set .envVars "PUBLIC_REPO_REDIRECTS" "\"true\"" -}}
-{{- $_ := set .envVars "QUERY_RUNNER_URL" "http://query-runner" -}}
 {{- $_ := set .envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set .envVars "REPO_UPDATER_URL" "http://repo-updater:3182" -}}
 {{- $_ := set .envVars "SEARCHER_URL" "k8s+http://searcher:3181" -}}

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,8 +42,6 @@ spec:
           value: sg
         - name: PUBLIC_REPO_REDIRECTS
           value: "true"
-        - name: QUERY_RUNNER_URL
-          value: http://query-runner
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
         - name: REPO_UPDATER_URL


### PR DESCRIPTION
The default value is `http://query-runner` in the code.

Related to https://github.com/sourcegraph/infrastructure/pull/604