### PR TITLE
remove REPO_UPDATER_URL

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -116,7 +116,6 @@
 
 {{- $_ := set .envVars "PUBLIC_REPO_REDIRECTS" "\"true\"" -}}
 {{- $_ := set .envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
-{{- $_ := set .envVars "REPO_UPDATER_URL" "http://repo-updater:3182" -}}
 {{- $_ := set .envVars "SEARCHER_URL" "k8s+http://searcher:3181" -}}
 {{- $_ := set .envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set .envVars "SRC_INDEXER" "indexer:3179" -}}

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: "true"
         - name: REDIS_MASTER_ENDPOINT
           value: redis-cache:6379
-        - name: REPO_UPDATER_URL
-          value: http://repo-updater:3182
         - name: SEARCHER_URL
           value: k8s+http://searcher:3181
         - name: SOURCEGRAPH_CONFIG_FILE


### PR DESCRIPTION
Rely on default behavior in the code.

See https://github.com/sourcegraph/infrastructure/pull/607