### PR TITLE
remove ZOEKT_HOST and rely on default behavior

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -52,8 +52,6 @@ spec:
           value: :6060
         - name: VAR
           value: val
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
           value: :6060
         - name: VAR
           value: val
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,7 +5,6 @@
 {{- include "collectFrontendCommonEnv" (dict "envVars" $envVars "Values" .Values "Files" .Files) }}
 {{- include "collectPostgresEnv" (dict "envVars" $envVars "Values" .Values) -}}
 {{- include "collectEnv" (list $envVars .Values.cluster.frontend.containers.frontend.env) -}}
-{{- $_ := set $envVars "ZOEKT_HOST" "indexed-search:80" -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,8 +50,6 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
         livenessProbe:
           httpGet:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: SRC_PROF_HTTP
           value: :6060
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
             secretKeyRef:
               key: key
               name: tls
-        image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -52,8 +52,6 @@ spec:
           value: :6060
         - name: TRACKING_APP_ID
           value: "123123123123"
-        - name: ZOEKT_HOST
-          value: indexed-search:80
         - name: TLS_CERT
           valueFrom:
             secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@
 # const defines configuration constants that generally should not be changed unless testing out experimental or pre-release features.
 const:
   frontend:
-    image: docker.sourcegraph.com/frontend:18152_2018-07-11_1db8b42
+    image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
   searcher:
     image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
   symbols:


### PR DESCRIPTION
- [x] update image after https://github.com/sourcegraph/sourcegraph/pull/12278 is merged