### PR TITLE
remove REDIS_MASTER_ENDPOINT and rely on default behavior

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -56,8 +56,6 @@ spec:
           value: gitserver-1:3178
         - name: VAR
           value: val
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: 9544ecc0711a4760bcba46a59afea8cb5916017f667fe43b618ec4dae9a25687
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: 9544ecc0711a4760bcba46a59afea8cb5916017f667fe43b618ec4dae9a25687
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: 9544ecc0711a4760bcba46a59afea8cb5916017f667fe43b618ec4dae9a25687
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -54,8 +54,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: ba3e71237fb5a564f99cfbec06bb58ce28f415901995d308fff5547a9b314f78
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -56,8 +56,6 @@ spec:
           value: tcp://xlang-ruby:8080
         - name: LANGSERVER_RUST
           value: tcp://xlang-rust:8080
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: 30b2283b452d5fb50293f1dc0c2993e1bec0497663b10667df336bfad5ba4757
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -54,8 +54,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: "true"
         - name: CONFIG_FILE_HASH
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/templates/indexer/indexer.Deployment.yaml
+++ b/templates/indexer/indexer.Deployment.yaml
@@ -4,7 +4,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "LSP_PROXY" "lsp-proxy:4388" -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 
 apiVersion: extensions/v1beta1

--- a/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: {{ $langserver.address | default (join "" (list "tcp://xlang-" $langserver.language ":8080")) }}
         {{- end }}
         {{- end }}
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/templates/repo-updater/repo-updater.Deployment.yaml
@@ -3,7 +3,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
-{{- $_ := set $envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set $envVars "REPO_LIST_UPDATE_INTERVAL" .Values.site.repoListUpdateInterval -}}
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -7,7 +7,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "NO_GO_GET_DOMAINS" .Values.site.noGoGetDomains -}}
 {{- $_ := set $envVars "CLONE_FROM_GITSERVER" (quote "true") -}}
-{{- $_ := set $envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- include "collectEnv" (list $envVars (index .Values.cluster.xlangGo.containers "xlang-go" ).env) -}}

--- a/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/templates/xlang/go/xlang-go.Deployment.yaml
@@ -7,7 +7,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "NO_GO_GET_DOMAINS" .Values.site.noGoGetDomains -}}
 {{- $_ := set $envVars "CLONE_FROM_GITSERVER" (quote "true") -}}
-{{- $_ := set $envVars "REDIS_MASTER_ENDPOINT" "redis-cache:6379" -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- include "collectEnv" (list $envVars (index .Values.cluster.xlangGo.containers "xlang-go" ).env) -}}

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -32,8 +32,6 @@ spec:
           value: gitserver-1:3178
         - name: LANGSERVER_HTML
           value: tcp://1.2.3.4:1234
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: 718c4d051e11d962879e2ae21662749b816d897dc692f1bc593557616e61cc21
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -36,8 +36,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SRC_PROF_HTTP
           value: :6060
         - name: POD_NAME

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -25,8 +25,6 @@ spec:
       - env:
         - name: CONFIG_FILE_HASH
           value: 2528a0893ab486460532ebc49de296b3ffc523807eca4a53c6735ac99d0857a0
-        - name: REDIS_MASTER_ENDPOINT
-          value: redis-cache:6379
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS


### PR DESCRIPTION
I believe all necessary images were already bumped in https://github.com/sourcegraph/deploy-sourcegraph/commit/344c0d582c80345af90beff275146eb53cda1dcf (lsp-proxy, repo-updater, xlang-go, indexer)

Going to wait for your review on this @keegancsmith 