### PR TITLE
remove SRC_PROF_HTTP and rely on default behavior

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: VAR
           value: val
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: VAR
           value: val
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: 9544ecc0711a4760bcba46a59afea8cb5916017f667fe43b618ec4dae9a25687
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         - name: VAR

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /data/repos
         - name: VAR
           value: val
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -56,8 +56,6 @@ spec:
           value: gitserver-1:3178
         - name: VAR
           value: val
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: VAR
           value: val
         - name: POD_NAME

--- a/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: VAR

--- a/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: VAR
           value: val
         - name: POD_NAME

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: VAR
           value: val
         - name: POD_NAME

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - env:
         - name: COMPOSER_AUTH
           value: '{"github-oauth": {"github.com": ""}}'
-        image: docker.sourcegraph.com/xlang-php:00034_2018-06-11_8fee935
+        image: docker.sourcegraph.com/xlang-php:00037_2018-07-11_faea319
         name: xlang-php
         ports:
         - containerPort: 2088

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: c382e72e1a7278843803db4ea55ff0bdb2dafe8200247c120189c04ceb01d280
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -60,7 +60,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -54,8 +54,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - env:
         - name: COMPOSER_AUTH
           value: '{"github-oauth": {"github.com": ""}}'
-        image: docker.sourcegraph.com/xlang-php:00034_2018-06-11_8fee935
+        image: docker.sourcegraph.com/xlang-php:00037_2018-07-11_faea319
         name: xlang-php
         ports:
         - containerPort: 2088

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: ba3e71237fb5a564f99cfbec06bb58ce28f415901995d308fff5547a9b314f78
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: 30b2283b452d5fb50293f1dc0c2993e1bec0497663b10667df336bfad5ba4757
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -56,8 +56,6 @@ spec:
           value: tcp://xlang-ruby:8080
         - name: LANGSERVER_RUST
           value: tcp://xlang-rust:8080
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: ad622f4e70f7edc1056a270559e8ca07bba00abd81c1bea1e8940c7156532081
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -60,7 +60,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -54,8 +54,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -31,8 +31,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - env:
         - name: COMPOSER_AUTH
           value: '{"github-oauth": {"github.com": ""}}'
-        image: docker.sourcegraph.com/xlang-php:00034_2018-06-11_8fee935
+        image: docker.sourcegraph.com/xlang-php:00037_2018-07-11_faea319
         name: xlang-php
         ports:
         - containerPort: 2088

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+        image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -116,7 +116,6 @@
 {{- $_ := set .envVars "PUBLIC_REPO_REDIRECTS" "\"true\"" -}}
 {{- $_ := set .envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
 {{- $_ := set .envVars "SRC_SESSION_COOKIE_KEY" .Values.site.sessionCookieKey -}}
-{{- $_ := set .envVars "SRC_PROF_HTTP" ":6060" -}}
 
 {{- end -}}
 

--- a/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/templates/github-proxy/github-proxy.Deployment.yaml
@@ -4,7 +4,6 @@
 {{- $_ := set $envVars "GITHUB_CLIENT_SECRET" .Values.site.githubClientSecret -}}
 {{- $_ := set $envVars "GITHUB_PERSONAL_ACCESS_TOKEN" .Values.site.githubPersonalAccessToken -}}
 {{- $_ := set $envVars "LOG_REQUESTS" "\"true\"" -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/gitserver/gitserver.Deployment.yaml
+++ b/templates/gitserver/gitserver.Deployment.yaml
@@ -2,7 +2,6 @@
 {{- $envVars := dict -}}
 {{- include "collectConfigEnv" (dict "envVars" $envVars "Values" $global.Values "Files" $global.Files) }}
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" $global.Values) }}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- $_ := set $envVars "SRC_REPOS_DIR" "/data/repos" -}}
 {{- $_ := set $envVars "ORIGIN_MAP" $global.Values.site.gitOriginMap -}}
 {{- include "collectEnv" (list $envVars .Values.cluster.gitserver.containers.gitserver.env) -}}

--- a/templates/indexer/indexer.Deployment.yaml
+++ b/templates/indexer/indexer.Deployment.yaml
@@ -4,7 +4,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "LSP_PROXY" "lsp-proxy:4388" -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -44,8 +44,6 @@ spec:
           value: {{ $langserver.address | default (join "" (list "tcp://xlang-" $langserver.language ":8080")) }}
         {{- end }}
         {{- end }}
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/templates/query-runner/query-runner.Deployment.yaml
+++ b/templates/query-runner/query-runner.Deployment.yaml
@@ -2,7 +2,6 @@
 {{- include "collectConfigEnv" (dict "envVars" $envVars "Values" .Values "Files" .Files) }}
 {{- include "collectCustomFrontendEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/templates/repo-updater/repo-updater.Deployment.yaml
@@ -2,7 +2,6 @@
 {{- include "collectConfigEnv" (dict "envVars" $envVars "Values" .Values "Files" .Files) }}
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- $_ := set $envVars "REPO_LIST_UPDATE_INTERVAL" .Values.site.repoListUpdateInterval -}}
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/templates/searcher/searcher.Deployment.yaml
+++ b/templates/searcher/searcher.Deployment.yaml
@@ -2,7 +2,6 @@
 {{- include "collectConfigEnv" (dict "envVars" $envVars "Values" .Values "Files" .Files) }}
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- $_ := set $envVars "SEARCHER_CACHE_SIZE_MB" "\"100000\"" -}}
 {{- include "collectEnv" (list $envVars .Values.cluster.searcher.containers.searcher.env) -}}
 

--- a/templates/symbols/symbols.Deployment.yaml
+++ b/templates/symbols/symbols.Deployment.yaml
@@ -2,7 +2,6 @@
 {{- include "collectConfigEnv" (dict "envVars" $envVars "Values" .Values "Files" .Files) }}
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- $_ := set $envVars "SYMBOLS_CACHE_SIZE_MB" "\"100000\"" -}}
 {{- include "collectEnv" (list $envVars .Values.cluster.symbols.containers.symbols.env) -}}
 

--- a/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -7,7 +7,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "NO_GO_GET_DOMAINS" .Values.site.noGoGetDomains -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- include "collectEnv" (list $envVars (index .Values.cluster.xlangGo.containers "xlang-go" ).env) -}}
 
 apiVersion: extensions/v1beta1

--- a/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/templates/xlang/go/xlang-go.Deployment.yaml
@@ -7,7 +7,6 @@
 {{- include "collectTracingEnv" (dict "envVars" $envVars "Values" .Values) }}
 {{- $_ := set $envVars "NO_GO_GET_DOMAINS" .Values.site.noGoGetDomains -}}
 {{- $_ := set $envVars "SRC_GIT_SERVERS" (include "gitservers" .) -}}
-{{- $_ := set $envVars "SRC_PROF_HTTP" ":6060" -}}
 {{- include "collectEnv" (list $envVars (index .Values.cluster.xlangGo.containers "xlang-go" ).env) -}}
 
 apiVersion: extensions/v1beta1

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
         livenessProbe:
           httpGet:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: 718c4d051e11d962879e2ae21662749b816d897dc692f1bc593557616e61cc21
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -32,8 +32,6 @@ spec:
           value: gitserver-1:3178
         - name: LANGSERVER_HTML
           value: tcp://1.2.3.4:1234
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
         name: query-runner
         ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,8 +48,6 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: TRACKING_APP_ID
           value: "123123123123"
         - name: TLS_CERT

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: key
               name: tls
-        image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+        image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
         name: github-proxy
         ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+        image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: 2528a0893ab486460532ebc49de296b3ffc523807eca4a53c6735ac99d0857a0
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SRC_REPOS_DIR
           value: /data/repos
         image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -40,8 +40,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
         name: indexer
         ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: http://localhost:3080
         - name: TRACKING_APP_ID
           value: "123123123123"
-        image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
         name: query-runner
         ports:
         - containerPort: 3183

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -1,5 +1,7 @@
 ##---
 # Source: sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -30,8 +32,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: TRACKING_APP_ID
           value: "123123123123"
         image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+        image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -29,8 +29,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
         name: repo-updater
         ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+        image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
         name: searcher
         ports:
         - containerPort: 3181

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -30,8 +30,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+        image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
         name: symbols
         ports:
         - containerPort: 3184

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -28,8 +28,6 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        - name: SRC_PROF_HTTP
-          value: :6060
         - name: SYMBOLS_CACHE_SIZE_MB
           value: "100000"
         - name: POD_NAME

--- a/values.yaml
+++ b/values.yaml
@@ -6,42 +6,42 @@
 # const defines configuration constants that generally should not be changed unless testing out experimental or pre-release features.
 const:
   frontend:
-    image: docker.sourcegraph.com/frontend:18154_2018-07-11_777963e
+    image: docker.sourcegraph.com/frontend:18282_2018-07-13_d76e9c6
   searcher:
-    image: docker.sourcegraph.com/searcher:17292_2018-06-20_03edd82
+    image: docker.sourcegraph.com/searcher:18235_2018-07-12_21a0f96
   symbols:
-    image: docker.sourcegraph.com/symbols:17100_2018-06-15_786c9d4
+    image: docker.sourcegraph.com/symbols:18236_2018-07-12_21a0f96
   gitserver:
-    image: docker.sourcegraph.com/gitserver:17094_2018-06-15_786c9d4
+    image: docker.sourcegraph.com/gitserver:18261_2018-07-13_07cdbb4
   githubProxy:
-    image: docker.sourcegraph.com/github-proxy:11943_2018-02-23_8bfb2ee
+    image: docker.sourcegraph.com/github-proxy:18230_2018-07-12_21a0f96
   indexedSearch:
     image: docker.sourcegraph.com/zoekt:18-05-30_3d2275e
   indexer:
-    image: docker.sourcegraph.com/indexer:18027_2018-07-10_9a03f6a
+    image: docker.sourcegraph.com/indexer:18231_2018-07-12_21a0f96
   lspProxy:
-    image: docker.sourcegraph.com/lsp-proxy:18028_2018-07-10_9a03f6a
+    image: docker.sourcegraph.com/lsp-proxy:18232_2018-07-12_21a0f96
   queryRunner:
-    image: docker.sourcegraph.com/query-runner:17097_2018-06-15_786c9d4
+    image: docker.sourcegraph.com/query-runner:18233_2018-07-12_21a0f96
   repoUpdater:
-    image: docker.sourcegraph.com/repo-updater:18029_2018-07-10_9a03f6a
+    image: docker.sourcegraph.com/repo-updater:18234_2018-07-12_21a0f96
   pgsql:
     exporterImage: docker.sourcegraph.com/pgsql-exporter:a294a9b6d83c139d3e1217f02c8f80a54cbf73ac
     image: docker.sourcegraph.com/postgres:9.4
   syntectServer:
     image: docker.sourcegraph.com/syntect_server:d4be6b90
   xlangGo:
-    image: docker.sourcegraph.com/xlang-go:18030_2018-07-10_9a03f6a
+    image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
   xlangJava:
     image: docker.sourcegraph.com/xlang-java-skinny:2018-07-12-1716
   xlangJavascriptTypescript:
-    image: docker.sourcegraph.com/xlang-javascript-typescript:00073_2018-06-21_90f79ed
+    image: docker.sourcegraph.com/xlang-javascript-typescript:00076_2018-07-11_83d2055
   npmProxy:
     image: docker.sourcegraph.com/npm-proxy:9d593e267b6f5e86caeb29da37f140c5f5f4c8b2
   xlangPython:
     image: docker.sourcegraph.com/xlang-python:17201_2018-06-18_9f1ba26
   xlangPHP:
-    image: docker.sourcegraph.com/xlang-php:00034_2018-06-11_8fee935
+    image: docker.sourcegraph.com/xlang-php:00037_2018-07-11_faea319
   redis:
     image: docker.sourcegraph.com/redis:18-02-07_8205764_3.2-alpine
     exporterImage: docker.sourcegraph.com/redis_exporter:18-02-07_bb60087_v0.15.0


### PR DESCRIPTION
Need to bump images:
- [x] sourcegraph-frontend
- [x] github-proxy
- [x] gitserver
- [x] indexer
- [x] lsp-proxy
- [x] query-runner
- [x] repo-updater
- [x] searcher
- [x] symbols
- [x] xlang-go

Other images that got updated
- xlang-typescript
- xlang-php