### PR TITLE
correct the outdated syntect_server version

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
           value: '{json=10485760}'
         - name: ROCKET_PORT
           value: "9238"
-        image: docker.sourcegraph.com/syntect_server:d4be6b90
+        image: docker.sourcegraph.com/syntect_server:624a1a2
         livenessProbe:
           httpGet:
             path: /health

--- a/update_docker_image_versions.py
+++ b/update_docker_image_versions.py
@@ -31,6 +31,15 @@ def main(params_path):
 
     if 'docker.sourcegraph.com/bitbucket-server' not in images:
         print('WARNING: bitbucket-server image is not present. Please ensure your kctx is pointing to dogfood')
+
+    # Override syntect_server version, since it is not automatically deployed
+    # to dogfood and as such we would be writing an outdated version by using
+    # the version found there.
+    syntect_server_name = 'docker.sourcegraph.com/syntect_server' 
+    if syntect_server_name not in images:
+        raise Exception("failed to find syntect_server in images, please report / fix this bug")
+    images[syntect_server_name] = '624a1a2'
+
     for name, tag in images.items():
         content = re.sub(r'image\: ({})\:([A-Za-z0-9\-\._]+)'.format(name), r'image: \1:{}'.format(tag), content)
     with open(params_path, 'w') as fd:

--- a/values.yaml
+++ b/values.yaml
@@ -29,7 +29,7 @@ const:
     exporterImage: docker.sourcegraph.com/pgsql-exporter:a294a9b6d83c139d3e1217f02c8f80a54cbf73ac
     image: docker.sourcegraph.com/postgres:9.4
   syntectServer:
-    image: docker.sourcegraph.com/syntect_server:d4be6b90
+    image: docker.sourcegraph.com/syntect_server:624a1a2
   xlangGo:
     image: docker.sourcegraph.com/xlang-go:18237_2018-07-12_21a0f96
   xlangJava:


### PR DESCRIPTION
The commit https://github.com/sourcegraph/deploy-sourcegraph/commit/b74e58681aeb4188df62ae6ce4932b50567664ce updated the syntect_server version using the new `update_docker_image_versions.py` script. However, our dogfood instance does not have automatic deployments of syntect_server (it is special in this regard), and hence using the version from there is incorrect as it can be outdated.

The syntect_server version is now hard-coded in `update_docker_image_versions.py`, and the `values.yaml` file has been manually adjusted to use the latest `syntect_server` version once again (done manually to avoid updating other image versions for a patch release).

This fixes a regression where e.g. Java files would be improperly highlighted. See internal issue: sourcegraph/sourcegraph#12537