### PR TITLE
add deploy: sourcegraph label to everything

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/aws/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/aws/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -12,3 +12,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/aws/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/aws/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/aws/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/aws/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/custom-env-vars/generated/sourcegraph/templates/auth-proxy/auth-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/auth-proxy/auth-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: HTTP basic auth proxy for sourcegraph-frontend
+  labels:
+    deploy: sourcegraph
   name: auth-proxy
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/auth-proxy/auth-proxy.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/auth-proxy/auth-proxy.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: auth-proxy
+    deploy: sourcegraph
   name: auth-proxy
 spec:
   loadBalancerIP: 0.0.0.0

--- a/examples/custom-env-vars/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/custom-env-vars/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -35,3 +35,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -6,4 +6,5 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -6,3 +6,4 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
+  deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Receives alerts from Prometheus and pushes them to OpsGenie.
+  labels:
+    deploy: sourcegraph
   name: alertmanager
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: alertmanager
+    deploy: sourcegraph
   name: alertmanager
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus-node-port
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
+  deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: 'default-prometheus'
+  labels:
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -476,3 +476,5 @@ data:
 kind: ConfigMap
 metadata:
   name: prometheus
+  labels:
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Collects metrics and aggregates them into graphs.
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
+  deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go-bg
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-go
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go
+    deploy: sourcegraph
   name: xlang-go
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java-bg
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+    deploy: sourcegraph
   name: xlang-java
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+  labels:   
     deploy: sourcegraph
   name: xlang-java
 spec:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java
+    deploy: sourcegraph
   name: xlang-java
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for PHP.
+  labels:
+    deploy: sourcegraph
   name: xlang-php
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-php
+    deploy: sourcegraph
   name: xlang-php
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,7 +5,9 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+  labels:   
     deploy: sourcegraph
+  app: xlang-java-bg
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python-bg
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-python
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python
+    deploy: sourcegraph
   name: xlang-python
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Cache for NPM.
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   accessModes:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: npm-proxy
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for background indexing
       jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript-bg
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   minReadySeconds: 10

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   ports:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,3 +13,4 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
+  deploy: sourcegraph

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,4 +13,5 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/gcp/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -12,3 +12,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/gcp/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/storage-class.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/storage-class.yaml
@@ -4,6 +4,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: default
+  labels:
+    deploy: sourcegraph
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd

--- a/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/gcp/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/manual-storage-class/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/manual-storage-class/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -12,3 +12,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/node-selector/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/node-selector/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -30,3 +30,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go-bg
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-go
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go
+    deploy: sourcegraph
   name: xlang-go
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java-bg
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+    deploy: sourcegraph
   name: xlang-java
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+  labels:   
     deploy: sourcegraph
   name: xlang-java
 spec:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java
+    deploy: sourcegraph
   name: xlang-java
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for PHP.
+  labels:
+    deploy: sourcegraph
   name: xlang-php
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-php
+    deploy: sourcegraph
   name: xlang-php
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,7 +5,9 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+  labels:   
     deploy: sourcegraph
+  app: xlang-java-bg
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python-bg
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-python
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python
+    deploy: sourcegraph
   name: xlang-python
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Cache for NPM.
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   accessModes:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: npm-proxy
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for background indexing
       jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript-bg
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   minReadySeconds: 10

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   ports:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,3 +13,4 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
+  deploy: sourcegraph

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,4 +13,5 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/prometheus/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -14,3 +14,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus-node-port
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
+  deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: 'default-prometheus'
+  labels:
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -476,3 +476,5 @@ data:
 kind: ConfigMap
 metadata:
   name: prometheus
+  labels:
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Collects metrics and aggregates them into graphs.
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
+  deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/storage-class.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/storage-class.yaml
@@ -4,6 +4,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: default
+  labels:
+    deploy: sourcegraph
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd

--- a/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/prometheus/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/with-exp-langs/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/with-exp-langs/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -51,3 +51,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/with-exp-langs/generated/sourcegraph/templates/xlang/experimental.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/xlang/experimental.yaml
@@ -23,6 +23,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for bash (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-bash
 spec:
@@ -79,6 +80,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for clojure (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-clojure
 spec:
@@ -135,6 +137,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for cpp (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-cpp
 spec:
@@ -191,6 +194,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for cs (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-cs
 spec:
@@ -247,6 +251,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for css (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-css
 spec:
@@ -303,6 +308,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for dockerfile (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-dockerfile
 spec:
@@ -359,6 +365,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for elixir (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-elixir
 spec:
@@ -415,6 +422,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for html (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-html
 spec:
@@ -471,6 +479,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for lua (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-lua
 spec:
@@ -527,6 +536,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for ocaml (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-ocaml
 spec:
@@ -583,6 +593,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for r (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-r
 spec:
@@ -639,6 +650,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for ruby (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-ruby
 spec:
@@ -695,6 +707,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for rust (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-rust
 spec:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/xlang/experimental.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/xlang/experimental.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-bash
+    deploy: sourcegraph
   name: xlang-bash
 spec:
   ports:
@@ -22,6 +23,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for bash (used for live requests).
+    deploy: sourcegraph
   name: xlang-bash
 spec:
   minReadySeconds: 10
@@ -59,6 +61,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-clojure
+    deploy: sourcegraph
   name: xlang-clojure
 spec:
   ports:
@@ -76,6 +79,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for clojure (used for live requests).
+    deploy: sourcegraph
   name: xlang-clojure
 spec:
   minReadySeconds: 10
@@ -113,6 +117,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-cpp
+    deploy: sourcegraph
   name: xlang-cpp
 spec:
   ports:
@@ -130,6 +135,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for cpp (used for live requests).
+    deploy: sourcegraph
   name: xlang-cpp
 spec:
   minReadySeconds: 10
@@ -167,6 +173,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-cs
+    deploy: sourcegraph
   name: xlang-cs
 spec:
   ports:
@@ -184,6 +191,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for cs (used for live requests).
+    deploy: sourcegraph
   name: xlang-cs
 spec:
   minReadySeconds: 10
@@ -221,6 +229,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-css
+    deploy: sourcegraph
   name: xlang-css
 spec:
   ports:
@@ -238,6 +247,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for css (used for live requests).
+    deploy: sourcegraph
   name: xlang-css
 spec:
   minReadySeconds: 10
@@ -275,6 +285,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-dockerfile
+    deploy: sourcegraph
   name: xlang-dockerfile
 spec:
   ports:
@@ -292,6 +303,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for dockerfile (used for live requests).
+    deploy: sourcegraph
   name: xlang-dockerfile
 spec:
   minReadySeconds: 10
@@ -329,6 +341,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-elixir
+    deploy: sourcegraph
   name: xlang-elixir
 spec:
   ports:
@@ -346,6 +359,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for elixir (used for live requests).
+    deploy: sourcegraph
   name: xlang-elixir
 spec:
   minReadySeconds: 10
@@ -383,6 +397,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-html
+    deploy: sourcegraph
   name: xlang-html
 spec:
   ports:
@@ -400,6 +415,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for html (used for live requests).
+    deploy: sourcegraph
   name: xlang-html
 spec:
   minReadySeconds: 10
@@ -437,6 +453,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-lua
+    deploy: sourcegraph
   name: xlang-lua
 spec:
   ports:
@@ -454,6 +471,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for lua (used for live requests).
+    deploy: sourcegraph
   name: xlang-lua
 spec:
   minReadySeconds: 10
@@ -491,6 +509,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-ocaml
+    deploy: sourcegraph
   name: xlang-ocaml
 spec:
   ports:
@@ -508,6 +527,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for ocaml (used for live requests).
+    deploy: sourcegraph
   name: xlang-ocaml
 spec:
   minReadySeconds: 10
@@ -545,6 +565,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-r
+    deploy: sourcegraph
   name: xlang-r
 spec:
   ports:
@@ -562,6 +583,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for r (used for live requests).
+    deploy: sourcegraph
   name: xlang-r
 spec:
   minReadySeconds: 10
@@ -599,6 +621,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-ruby
+    deploy: sourcegraph
   name: xlang-ruby
 spec:
   ports:
@@ -616,6 +639,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for ruby (used for live requests).
+    deploy: sourcegraph
   name: xlang-ruby
 spec:
   minReadySeconds: 10
@@ -653,6 +677,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-rust
+    deploy: sourcegraph
   name: xlang-rust
 spec:
   ports:
@@ -670,6 +695,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for rust (used for live requests).
+    deploy: sourcegraph
   name: xlang-rust
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/backend.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/examples/with-langs/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -30,3 +30,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go-bg
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-go
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go
+    deploy: sourcegraph
   name: xlang-go
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java-bg
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+    deploy: sourcegraph
   name: xlang-java
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+  labels:   
     deploy: sourcegraph
   name: xlang-java
 spec:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/java/xlang-java.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java
+    deploy: sourcegraph
   name: xlang-java
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for PHP.
+  labels:
+    deploy: sourcegraph
   name: xlang-php
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/php/xlang-php.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-php
+    deploy: sourcegraph
   name: xlang-php
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,7 +5,9 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+  labels:   
     deploy: sourcegraph
+  app: xlang-java-bg
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python-bg
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-python
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/python/xlang-python.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python
+    deploy: sourcegraph
   name: xlang-python
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Cache for NPM.
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   accessModes:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/npm-proxy.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: npm-proxy
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for background indexing
       jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript-bg
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   minReadySeconds: 10

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/xlang-typescript.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   ports:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,3 +13,4 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
+  deploy: sourcegraph

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -13,4 +13,5 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/templates/auth-proxy/auth-proxy.Deployment.yaml
+++ b/templates/auth-proxy/auth-proxy.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: HTTP basic auth proxy for sourcegraph-frontend
+  labels:
+    deploy: sourcegraph
   name: auth-proxy
 spec:
   minReadySeconds: 10

--- a/templates/auth-proxy/auth-proxy.Service.yaml
+++ b/templates/auth-proxy/auth-proxy.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: auth-proxy
+    deploy: sourcegraph
   name: auth-proxy
 spec:
   loadBalancerIP: {{ .Values.site.authProxyIP }}

--- a/templates/backend.Service.yaml
+++ b/templates/backend.Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/templates/config-file.ConfigMap.yaml
+++ b/templates/config-file.ConfigMap.yaml
@@ -5,3 +5,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -11,6 +11,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -4,3 +4,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -4,4 +4,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/templates/github-proxy/github-proxy.Deployment.yaml
@@ -10,6 +10,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/templates/github-proxy/github-proxy.Deployment.yaml
@@ -10,7 +10,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/templates/github-proxy/github-proxy.Service.yaml
+++ b/templates/github-proxy/github-proxy.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/templates/gitserver/gitserver-ssh.Secret.yaml
+++ b/templates/gitserver/gitserver-ssh.Secret.yaml
@@ -7,6 +7,7 @@ data:
 kind: Secret
 metadata:
   name: gitserver-ssh
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 type: Opaque
 {{end}}

--- a/templates/gitserver/gitserver-ssh.Secret.yaml
+++ b/templates/gitserver/gitserver-ssh.Secret.yaml
@@ -7,5 +7,6 @@ data:
 kind: Secret
 metadata:
   name: gitserver-ssh
+  deploy: sourcegraph
 type: Opaque
 {{end}}

--- a/templates/gitserver/gitserver.Deployment.yaml
+++ b/templates/gitserver/gitserver.Deployment.yaml
@@ -15,6 +15,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-{{ add1 $gitserverIndex }}
 spec:
   minReadySeconds: 10

--- a/templates/gitserver/gitserver.Deployment.yaml
+++ b/templates/gitserver/gitserver.Deployment.yaml
@@ -15,6 +15,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-{{ add1 $gitserverIndex }}
 spec:

--- a/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -8,6 +8,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ $global.Values.cluster.storageClass.name }}
+  deploy: sourcegraph
   name: gitserver-{{ add1 $gitserverIndex }}
 spec:
   accessModes:

--- a/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -8,7 +8,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ $global.Values.cluster.storageClass.name }}
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-{{ add1 $gitserverIndex }}
 spec:
   accessModes:

--- a/templates/gitserver/gitserver.Service.yaml
+++ b/templates/gitserver/gitserver.Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -24,6 +25,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-{{ add1 $gitserverIndex }}
   name: gitserver-{{ add1 $gitserverIndex }}
 spec:

--- a/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/templates/indexed-search/indexed-search.Deployment.yaml
@@ -3,7 +3,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/templates/indexed-search/indexed-search.Deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -3,7 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/templates/indexed-search/indexed-search.Service.yaml
+++ b/templates/indexed-search/indexed-search.Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/templates/indexer/indexer.Deployment.yaml
+++ b/templates/indexer/indexer.Deployment.yaml
@@ -11,7 +11,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/templates/indexer/indexer.Deployment.yaml
+++ b/templates/indexer/indexer.Deployment.yaml
@@ -11,6 +11,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/templates/indexer/indexer.Service.yaml
+++ b/templates/indexer/indexer.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/templates/jaeger/jaeger-cassandra.Deployment.yaml
+++ b/templates/jaeger/jaeger-cassandra.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Database for Jaeger.
+  labels:
+    deploy: sourcegraph
   name: jaeger-cassandra
 spec:
   minReadySeconds: 10

--- a/templates/jaeger/jaeger-cassandra.Service.yaml
+++ b/templates/jaeger/jaeger-cassandra.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-cassandra
+    deploy: sourcegraph
   name: jaeger-cassandra
 spec:
   ports:

--- a/templates/jaeger/jaeger-collector.Deployment.yaml
+++ b/templates/jaeger/jaeger-collector.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Receives traces from Jaeger agents.
+  labels:
+    deploy: sourcegraph
   name: jaeger-collector
 spec:
   minReadySeconds: 10

--- a/templates/jaeger/jaeger-collector.Service.yaml
+++ b/templates/jaeger/jaeger-collector.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-collector
+    deploy: sourcegraph
   name: jaeger-collector
 spec:
   ports:

--- a/templates/jaeger/jaeger-query.Deployment.yaml
+++ b/templates/jaeger/jaeger-query.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Frontend for querying traces.
+  labels:
+    deploy: sourcegraph
   name: jaeger-query
 spec:
   minReadySeconds: 10

--- a/templates/jaeger/jaeger-query.Service.yaml
+++ b/templates/jaeger/jaeger-query.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-query
+    deploy: sourcegraph
   name: jaeger-query
 spec:
   ports:

--- a/templates/jaeger/jaeger.PersistentVolumeClaim.yaml
+++ b/templates/jaeger/jaeger.PersistentVolumeClaim.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: jaeger
 spec:
   accessModes:

--- a/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -19,6 +19,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/templates/node-ssd/pod-tmp-gc.ClusterRole.yaml
+++ b/templates/node-ssd/pod-tmp-gc.ClusterRole.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: pod-tmp-gc
+  labels:
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/templates/node-ssd/pod-tmp-gc.ClusterRoleBinding.yaml
+++ b/templates/node-ssd/pod-tmp-gc.ClusterRoleBinding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: '{{.Release.Namespace}}-pod-tmp-gc'
+  labels:
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/templates/node-ssd/pod-tmp-gc.DaemonSet.yaml
+++ b/templates/node-ssd/pod-tmp-gc.DaemonSet.yaml
@@ -3,6 +3,8 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: pod-tmp-gc
+  labels:
+    deploy: sourcegraph
 spec:
   template:
     metadata:

--- a/templates/node-ssd/pod-tmp-gc.ServiceAccount.yaml
+++ b/templates/node-ssd/pod-tmp-gc.ServiceAccount.yaml
@@ -5,4 +5,6 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: pod-tmp-gc
+  labels:
+    deploy: sourcegraph
 {{- end -}}

--- a/templates/pgsql/pgsql.Deployment.yaml
+++ b/templates/pgsql/pgsql.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/templates/pgsql/pgsql.Service.yaml
+++ b/templates/pgsql/pgsql.Service.yaml
@@ -7,6 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -10,4 +10,5 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
+  deploy: sourcegraph
 {{- end -}}

--- a/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -10,5 +10,6 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 {{- end -}}

--- a/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
+++ b/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Receives alerts from Prometheus and pushes them to OpsGenie.
+  labels:
+    deploy: sourcegraph
   name: alertmanager
 spec:
   minReadySeconds: 10

--- a/templates/prometheus/alertmanager/alertmanager.Service.yaml
+++ b/templates/prometheus/alertmanager/alertmanager.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: alertmanager
+    deploy: sourcegraph
   name: alertmanager
 spec:
   ports:

--- a/templates/prometheus/prometheus-node-port.Service.yaml
+++ b/templates/prometheus/prometheus-node-port.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus-node-port
 spec:
   ports:

--- a/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/templates/prometheus/prometheus.ClusterRole.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/templates/prometheus/prometheus.ClusterRole.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
+  deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: '{{.Release.Namespace}}-prometheus'
+  labels:
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/templates/prometheus/prometheus.ConfigMap.yaml
@@ -485,4 +485,6 @@ data:
 kind: ConfigMap
 metadata:
   name: prometheus
+  labels:
+    deploy: sourcegraph
 {{ end -}}

--- a/templates/prometheus/prometheus.Deployment.yaml
+++ b/templates/prometheus/prometheus.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Collects metrics and aggregates them into graphs.
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   accessModes:

--- a/templates/prometheus/prometheus.Service.yaml
+++ b/templates/prometheus/prometheus.Service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus
 spec:
   ports:

--- a/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -5,5 +5,6 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 {{ end -}}

--- a/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -5,4 +5,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
+  deploy: sourcegraph
 {{ end -}}

--- a/templates/query-runner/query-runner.Deployment.yaml
+++ b/templates/query-runner/query-runner.Deployment.yaml
@@ -8,6 +8,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/templates/query-runner/query-runner.Deployment.yaml
+++ b/templates/query-runner/query-runner.Deployment.yaml
@@ -8,7 +8,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/templates/query-runner/query-runner.Service.yaml
+++ b/templates/query-runner/query-runner.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/templates/redis/redis-cache.ConfigMap.yaml
+++ b/templates/redis/redis-cache.ConfigMap.yaml
@@ -15,4 +15,6 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph
 {{end -}}

--- a/templates/redis/redis-cache.Deployment.yaml
+++ b/templates/redis/redis-cache.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/templates/redis/redis-cache.Service.yaml
+++ b/templates/redis/redis-cache.Service.yaml
@@ -7,6 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/templates/redis/redis-store.ConfigMap.yaml
+++ b/templates/redis/redis-store.ConfigMap.yaml
@@ -16,4 +16,6 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph
 {{end -}}

--- a/templates/redis/redis-store.Deployment.yaml
+++ b/templates/redis/redis-store.Deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/templates/redis/redis-store.Service.yaml
+++ b/templates/redis/redis-store.Service.yaml
@@ -7,6 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/templates/repo-updater/repo-updater.Deployment.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/templates/repo-updater/repo-updater.Service.yaml
+++ b/templates/repo-updater/repo-updater.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/templates/searcher/searcher.Deployment.yaml
+++ b/templates/searcher/searcher.Deployment.yaml
@@ -10,6 +10,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/templates/searcher/searcher.Service.yaml
+++ b/templates/searcher/searcher.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/templates/storage-class.yaml
+++ b/templates/storage-class.yaml
@@ -7,6 +7,8 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: {{ $storageClassName }}
+  labels:
+    deploy: sourcegraph
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd

--- a/templates/symbols/symbols.Deployment.yaml
+++ b/templates/symbols/symbols.Deployment.yaml
@@ -10,6 +10,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/templates/symbols/symbols.Service.yaml
+++ b/templates/symbols/symbols.Service.yaml
@@ -6,6 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/templates/syntect-server/syntect-server.Deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/templates/syntect-server/syntect-server.Service.yaml
+++ b/templates/syntect-server/syntect-server.Service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/templates/tls.Secret.yaml
+++ b/templates/tls.Secret.yaml
@@ -5,4 +5,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/templates/xlang/experimental.yaml
+++ b/templates/xlang/experimental.yaml
@@ -13,6 +13,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-{{ $langserver.language }}
+    deploy: sourcegraph
   name: xlang-{{ $langserver.language }}
 spec:
   ports:
@@ -30,6 +31,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for {{ $langserver.language }} (used for live requests).
+    deploy: sourcegraph
   name: xlang-{{ $langserver.language }}
 spec:
   minReadySeconds: 10

--- a/templates/xlang/experimental.yaml
+++ b/templates/xlang/experimental.yaml
@@ -31,6 +31,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for {{ $langserver.language }} (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-{{ $langserver.language }}
 spec:

--- a/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -15,6 +15,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   minReadySeconds: 10

--- a/templates/xlang/go/xlang-go-bg.Service.yaml
+++ b/templates/xlang/go/xlang-go-bg.Service.yaml
@@ -9,6 +9,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go-bg
+    deploy: sourcegraph
   name: xlang-go-bg
 spec:
   ports:

--- a/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/templates/xlang/go/xlang-go.Deployment.yaml
@@ -15,6 +15,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Go (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-go
 spec:
   minReadySeconds: 10

--- a/templates/xlang/go/xlang-go.Service.yaml
+++ b/templates/xlang/go/xlang-go.Service.yaml
@@ -9,6 +9,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: xlang-go
+    deploy: sourcegraph
   name: xlang-go
 spec:
   ports:

--- a/templates/xlang/java/xlang-java-bg.Deployment.yaml
+++ b/templates/xlang/java/xlang-java-bg.Deployment.yaml
@@ -18,6 +18,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for background indexing jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   minReadySeconds: 10

--- a/templates/xlang/java/xlang-java-bg.Service.yaml
+++ b/templates/xlang/java/xlang-java-bg.Service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java-bg
+    deploy: sourcegraph
   name: xlang-java-bg
 spec:
   ports:

--- a/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/templates/xlang/java/xlang-java.Deployment.yaml
@@ -18,6 +18,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+    deploy: sourcegraph
   name: xlang-java
 spec:
   minReadySeconds: 10

--- a/templates/xlang/java/xlang-java.Deployment.yaml
+++ b/templates/xlang/java/xlang-java.Deployment.yaml
@@ -18,6 +18,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Java (used for live requests).
+  labels:   
     deploy: sourcegraph
   name: xlang-java
 spec:

--- a/templates/xlang/java/xlang-java.Service.yaml
+++ b/templates/xlang/java/xlang-java.Service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-java
+    deploy: sourcegraph
   name: xlang-java
 spec:
   ports:

--- a/templates/xlang/php/xlang-php.Deployment.yaml
+++ b/templates/xlang/php/xlang-php.Deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for PHP.
+  labels:
+    deploy: sourcegraph
   name: xlang-php
 spec:
   minReadySeconds: 10

--- a/templates/xlang/php/xlang-php.Service.yaml
+++ b/templates/xlang/php/xlang-php.Service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-php
+    deploy: sourcegraph
   name: xlang-php
 spec:
   ports:

--- a/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -11,6 +11,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/templates/xlang/python/xlang-python-bg.Deployment.yaml
+++ b/templates/xlang/python/xlang-python-bg.Deployment.yaml
@@ -11,7 +11,9 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for background indexing jobs).
+  labels:   
     deploy: sourcegraph
+  app: xlang-java-bg
   name: xlang-python-bg
 spec:
   minReadySeconds: 10

--- a/templates/xlang/python/xlang-python-bg.Service.yaml
+++ b/templates/xlang/python/xlang-python-bg.Service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python-bg
+    deploy: sourcegraph
   name: xlang-python-bg
 spec:
   ports:

--- a/templates/xlang/python/xlang-python.Deployment.yaml
+++ b/templates/xlang/python/xlang-python.Deployment.yaml
@@ -11,6 +11,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for Python (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-python
 spec:
   minReadySeconds: 10

--- a/templates/xlang/python/xlang-python.Service.yaml
+++ b/templates/xlang/python/xlang-python.Service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-python
+    deploy: sourcegraph
   name: xlang-python
 spec:
   ports:

--- a/templates/xlang/typescript/npm-proxy.Deployment.yaml
+++ b/templates/xlang/typescript/npm-proxy.Deployment.yaml
@@ -9,6 +9,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Cache for NPM.
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   minReadySeconds: 10

--- a/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
+++ b/templates/xlang/typescript/npm-proxy.PersistentVolumeClaim.yaml
@@ -9,6 +9,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.cluster.storageClass.name }}
+  labels:
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   accessModes:

--- a/templates/xlang/typescript/npm-proxy.Service.yaml
+++ b/templates/xlang/typescript/npm-proxy.Service.yaml
@@ -9,6 +9,7 @@ kind: Service
 metadata:
   labels:
     app: npm-proxy
+    deploy: sourcegraph
   name: npm-proxy
 spec:
   ports:

--- a/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
+++ b/templates/xlang/typescript/xlang-typescript-bg.Deployment.yaml
@@ -14,6 +14,8 @@ metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for background indexing
       jobs).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   minReadySeconds: 10

--- a/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
+++ b/templates/xlang/typescript/xlang-typescript-bg.Service.yaml
@@ -9,6 +9,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript-bg
+    deploy: sourcegraph
   name: xlang-typescript-bg
 spec:
   ports:

--- a/templates/xlang/typescript/xlang-typescript.Deployment.yaml
+++ b/templates/xlang/typescript/xlang-typescript.Deployment.yaml
@@ -13,6 +13,8 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for JavaScript and TypeScript (used for live requests).
+  labels:
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   minReadySeconds: 10

--- a/templates/xlang/typescript/xlang-typescript.Service.yaml
+++ b/templates/xlang/typescript/xlang-typescript.Service.yaml
@@ -9,6 +9,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-typescript
+    deploy: sourcegraph
   name: xlang-typescript
 spec:
   ports:

--- a/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -17,4 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
+  deploy: sourcegraph
 {{ end -}}

--- a/templates/xlang/typescript/yarn-config.ConfigMap.yaml
+++ b/templates/xlang/typescript/yarn-config.ConfigMap.yaml
@@ -17,5 +17,6 @@ data:
 kind: ConfigMap
 metadata:
   name: yarn-config
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 {{ end -}}

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/backend.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/xlang/experimental.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/xlang/experimental.yaml
@@ -23,6 +23,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for html (used for live requests).
+  labels:
     deploy: sourcegraph
   name: xlang-html
 spec:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/xlang/experimental.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/xlang/experimental.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: xlang-html
+    deploy: sourcegraph
   name: xlang-html
 spec:
   ports:
@@ -22,6 +23,7 @@ kind: Deployment
 metadata:
   annotations:
     description: LSP server for html (used for live requests).
+    deploy: sourcegraph
   name: xlang-html
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/backend.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/backend.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     group: backend
+    deploy: sourcegraph
   name: backend
 spec:
   clusterIP: None

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/config-file.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/config-file.ConfigMap.yaml
@@ -21,3 +21,5 @@ data:
 kind: ConfigMap
 metadata:
   name: config-file
+  labels:
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Serves the frontend of Sourcegraph via HTTP(S).
+  labels:
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: sourcegraph-frontend
+  labels:
+    deploy: soucegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: sourcegraph-frontend
   labels:
-    deploy: soucegraph
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,6 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -5,7 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: Role

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: sourcegraph-frontend
+    deploy: sourcegraph
   name: sourcegraph-frontend
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: sourcegraph-frontend
+  deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
+  deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Rate-limiting proxy for the GitHub API.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: github-proxy
+    deploy: sourcegraph
   name: github-proxy
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver-ssh.Secret.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver-ssh.Secret.yaml
@@ -10,6 +10,7 @@ data:
 kind: Secret
 metadata:
   name: gitserver-ssh
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 type: Opaque
 

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver-ssh.Secret.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver-ssh.Secret.yaml
@@ -10,5 +10,6 @@ data:
 kind: Secret
 metadata:
   name: gitserver-ssh
+  deploy: sourcegraph
 type: Opaque
 

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+  labels:   
     deploy: sourcegraph
   name: gitserver-1
 spec:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Stores clones of repositories to perform Git operations.
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: gitserver-1
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     type: gitserver
+    deploy: sourcegraph
   name: gitserver
 spec:
   clusterIP: None
@@ -23,6 +24,7 @@ metadata:
     prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
   labels:
+    deploy: sourcegraph
     app: gitserver-1
   name: gitserver-1
 spec:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
+  deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for indexed text search operations.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,7 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.PersistentVolumeClaim.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  deploy: sourcegraph
   name: indexed-search
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexed-search/indexed-search.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: indexed-search
+    deploy: sourcegraph
   name: indexed-search
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,7 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Asynchronous indexing for global references.
+  deploy: sourcegraph
   name: indexer
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: indexer
+    deploy: sourcegraph
   name: indexer
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-cassandra.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-cassandra.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Database for Jaeger.
+  labels:
+    deploy: sourcegraph
   name: jaeger-cassandra
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-cassandra.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-cassandra.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-cassandra
+    deploy: sourcegraph
   name: jaeger-cassandra
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-collector.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-collector.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Receives traces from Jaeger agents.
+  labels:
+    deploy: sourcegraph
   name: jaeger-collector
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-collector.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-collector
+    deploy: sourcegraph
   name: jaeger-collector
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-query.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-query.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Frontend for querying traces.
+  labels:
+    deploy: sourcegraph
   name: jaeger-query
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger-query.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: jaeger-query
+    deploy: sourcegraph
   name: jaeger-query
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/jaeger/jaeger.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: jaeger
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Multiplexer between frontend and LSP servers.
+  labels:
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: lsp-proxy
+    deploy: sourcegraph
   name: lsp-proxy
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Postgres database for various data.
+  labels: 
+    deploy: sourcegraph
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: pgsql
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/pgsql/pgsql.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pgsql
+    deploy: sourcegraph
   name: pgsql
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -9,3 +9,4 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
+  deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.ConfigMap.yaml
@@ -9,4 +9,5 @@ data:
 kind: ConfigMap
 metadata:
   name: alertmanager
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Receives alerts from Prometheus and pushes them to OpsGenie.
+  labels:
+    deploy: sourcegraph
   name: alertmanager
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/alertmanager/alertmanager.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: alertmanager
+    deploy: sourcegraph
   name: alertmanager
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus-node-port.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus-node-port
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRole.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
+  deploy: sourcegraph
 rules:
 - apiGroups:
   - ""

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: 'default-prometheus'
+  labels:
+    deploy: sourcegraph
 roleRef:
   apiGroup: ""
   kind: ClusterRole

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
@@ -484,3 +484,5 @@ data:
 kind: ConfigMap
 metadata:
   name: prometheus
+  labels:
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Collects metrics and aggregates them into graphs.
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: prometheus
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: prometheus
+    deploy: sourcegraph
   name: prometheus
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,3 +6,4 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
+  deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/prometheus/prometheus.ServiceAccount.yaml
@@ -6,4 +6,5 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: prometheus
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,7 +7,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
-  deploy: sourcegraph
+  labels:   
+    deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -7,6 +7,7 @@ kind: Deployment
 metadata:
   annotations:
     description: Saved search query runner / notification service.
+  deploy: sourcegraph
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: query-runner
+    deploy: sourcegraph
   name: query-runner
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.ConfigMap.yaml
@@ -16,3 +16,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-cache
+  labels:
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing short-lived caches.
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-cache
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-cache.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-cache
+    deploy: sourcegraph
   name: redis-cache
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.ConfigMap.yaml
@@ -17,3 +17,5 @@ data:
 kind: ConfigMap
 metadata:
   name: redis-store
+  labels:
+    deploy: sourcegraph

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Redis for storing semi-persistent data like user sessions.
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.PersistentVolumeClaim.yaml
@@ -5,6 +5,8 @@ kind: PersistentVolumeClaim
 metadata:
   annotations:
     volume.beta.kubernetes.io/storage-class: default
+  labels:
+    deploy: sourcegraph
   name: redis-store
 spec:
   accessModes:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/redis/redis-store.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: redis-store
+    deploy: sourcegraph
   name: redis-store
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: Handles repository metadata (not Git data) lookups and updates from
       external code hosts and other similar services.
+  labels:
+    deploy: sourcegraph
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: repo-updater
+    deploy: sourcegraph
   name: repo-updater
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for text search operations.
+  labels:
+    deploy: sourcegraph
   name: searcher
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: searcher
+    deploy: sourcegraph
   name: searcher
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for symbols operations.
+  labels:
+    deploy: sourcegraph
   name: symbols
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: symbols
+    deploy: sourcegraph
   name: symbols
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   annotations:
     description: Backend for syntax highlighting operations.
+  labels:
+    deploy: sourcegraph
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/syntect-server/syntect-server.Service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app: syntect-server
+    deploy: sourcegraph
   name: syntect-server
 spec:
   ports:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/tls.Secret.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/tls.Secret.yaml
@@ -7,4 +7,6 @@ data:
 kind: Secret
 metadata:
   name: tls
+  labels:
+    deploy: sourcegraph
 type: Opaque


### PR DESCRIPTION
Maybe not necessary, but it might be helpful for https://github.com/sourcegraph/deploy-sourcegraph/pull/58