### PR TITLE
fix gitserver replica count script

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -318,10 +318,12 @@ Here is a convenience script that performs both steps:
 ```bash
 # This script requires https://github.com/sourcegraph/jy and https://github.com/sourcegraph/yj
 
+GS=base/gitserver/gitserver.StatefulSet.yaml
+
 REPLICA_COUNT=2 # number of gitserver replicas
 
 # Update gitserver replica count
-cat $GS | yj | jq ".spec.replicas = \"$REPLICA_COUNT\"" | jy -o $GS
+cat $GS | yj | jq ".spec.replicas = $REPLICA_COUNT" | jy -o $GS
 
 # Compute all gitserver names
 GITSERVERS=$(for i in `seq 0 $(($REPLICA_COUNT-1))`; do echo -n "gitserver-$i.gitserver:3178 "; done)


### PR DESCRIPTION
This PR adds the `GS` variable's definition (which was missing before), and remove the quotes around `replicas: n` that the old script would insert. 