### PR TITLE
Double CPU resources for frontend

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -47,7 +47,7 @@ spec:
           value: "true"
         - name: SRC_GIT_SERVERS
           value: gitserver-0.gitserver:3178
-        # See the customization guide (../../../docs/configure.md) for information 
+        # See the customization guide (../../../docs/configure.md) for information
         # about how to configure Sourcegraph to use TLS
         # - name: TLS_CERT
         #   valueFrom:
@@ -78,10 +78,10 @@ spec:
         resources:
           limits:
             cpu: "2"
-            memory: 2G
+            memory: 4G
           requests:
             cpu: "2"
-            memory: 1G
+            memory: 2G
         volumeMounts:
         - mountPath: /etc/sourcegraph
           name: sg-config


### PR DESCRIPTION
@keegancsmith spent time debugging https://github.com/sourcegraph/sourcegraph/issues/11253 and found out that ultimately, searches with tons of results causes an OOM in frontend. We implemented https://github.com/sourcegraph/sourcegraph/commit/c89f07406e4461726a04a0b783d023985d8d9803 to limit the number of results Zoekt would return since it wasn't following the limits the user would set in `max`, but this doesn't solve the reproducible case in the issue. Ultimately, to solve it, we would need to bump the CPU resources in frontend.