### PR TITLE
include `provisioner` field in docs

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -410,6 +410,7 @@ Sourcegraph expects there to be storage class named `sourcegraph` that it uses f
 
      ```yaml
      # base/sourcegraph.StorageClass.yaml
+     provisioner: kubernetes.io/gce-pd
      parameters:
        type: pd-ssd
      ```
@@ -418,6 +419,7 @@ Sourcegraph expects there to be storage class named `sourcegraph` that it uses f
 
      ```yaml
      # base/sourcegraph.StorageClass.yaml
+     provisioner: kubernetes.io/aws-ebs
      parameters:
        type: gp2
      ```
@@ -426,6 +428,7 @@ Sourcegraph expects there to be storage class named `sourcegraph` that it uses f
 
      ```yaml
      # base/sourcegraph.StorageClass.yaml
+     provisioner: kubernetes.io/azure-disk
      parameters:
        storageaccounttype: Premium_LRS
      ```


### PR DESCRIPTION
When I was going through these install instructions, I missed the `provisioner` field the first time because I was just copy-pasting the snippets. Any reason not to include these?