### PR TITLE
xlang: add instruction in docs to add entry to site configuration when you enable a language server

### DIFF
--- a/configure/xlang/experimental/bash/README.md
+++ b/configure/xlang/experimental/bash/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-bash -f configure/experimental/bash --recursive >> kubectl-apply-all.sh
    ```
 
-2. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Bash language server's existence.
+1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Bash language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-bash:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Bash language server to the cluster.
+1. Add the following entry for the Bash language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "bash"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Bash language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/bash/README.md
+++ b/configure/xlang/experimental/bash/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-bash -f configure/experimental/bash --recursive >> kubectl-apply-all.sh
    ```
 
-1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Bash language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_BASH
-       value: tcp://xlang-bash:8080
-   ```
-
 1. Add the following entry for the Bash language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "bash"
+           "language": "bash",
+           "address": "tcp://xlang-bash:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Bash language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Bash language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/clojure/README.md
+++ b/configure/xlang/experimental/clojure/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-clojure -f configure/experimental/clojure --recursive >> kubectl-apply-all.sh
    ```
 
-2. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Clojure language server's existence.
+1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Clojure language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-clojure:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Clojure language server to the cluster.
+1. Add the following entry for the Clojure language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "clojure"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Clojure language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/clojure/README.md
+++ b/configure/xlang/experimental/clojure/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-clojure -f configure/experimental/clojure --recursive >> kubectl-apply-all.sh
    ```
 
-1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Clojure language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_CLOJURE
-       value: tcp://xlang-clojure:8080
-   ```
-
 1. Add the following entry for the Clojure language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "clojure"
+           "language": "clojure",
+           "address": "tcp://xlang-clojure:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Clojure language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Clojure language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/cpp/README.md
+++ b/configure/xlang/experimental/cpp/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-cpp -f configure/experimental/cpp --recursive >> kubectl-apply-all.sh
    ```
 
-1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the C++ language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_CPP
-       value: tcp://xlang-cpp:8080
-   ```
-
 1. Add the following entry for the C++ language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "cpp"
+           "language": "cpp",
+           "address": "tcp://xlang-cpp:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C++ language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the C++ language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/cpp/README.md
+++ b/configure/xlang/experimental/cpp/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-cpp -f configure/experimental/cpp --recursive >> kubectl-apply-all.sh
    ```
 
-2. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the C++ language server's existence.
+1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the C++ language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-cpp:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the C++ language server to the cluster.
+1. Add the following entry for the C++ language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "cpp"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C++ language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/cs/README.md
+++ b/configure/xlang/experimental/cs/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-cs -f configure/experimental/cs --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the C# language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_CS
-       value: tcp://xlang-cs:8080
-   ```
-
 1. Add the following entry for the C# language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "cs"
+           "language": "cs",
+           "address": "tcp://xlang-cs:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C# language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the C# language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/cs/README.md
+++ b/configure/xlang/experimental/cs/README.md
@@ -36,7 +36,7 @@ You can enable it by:
      }
    ```
 
-1) Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C# language server to the cluster.
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C# language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/cs/README.md
+++ b/configure/xlang/experimental/cs/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-cs -f configure/experimental/cs --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the C# language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the C# language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-cs:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the C# language server to the cluster.
+1. Add the following entry for the C# language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "cs"
+         }
+       ]
+     }
+   ```
+
+1) Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the C# language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/css/README.md
+++ b/configure/xlang/experimental/css/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-css -f configure/experimental/css --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the CSS language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the CSS language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-css:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the CSS language server to the cluster.
+1. Add the following entry for the CSS language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "css"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the CSS language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/css/README.md
+++ b/configure/xlang/experimental/css/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-css -f configure/experimental/css --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the CSS language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_CSS
-       value: tcp://xlang-css:8080
-   ```
-
 1. Add the following entry for the CSS language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "css"
+           "language": "css",
+           "address": "tcp://xlang-css:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the CSS language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the CSS language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/dockerfile/README.md
+++ b/configure/xlang/experimental/dockerfile/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-dockerfile -f configure/experimental/dockerfile --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Dockerfile language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_DOCKERFILE
-       value: tcp://xlang-dockerfile:8080
-   ```
-
 1. Add the following entry for the Dockerfile language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "dockerfile"
+           "language": "dockerfile",
+           "address": "tcp://xlang-dockerfile:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Dockerfile language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Dockerfile language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/dockerfile/README.md
+++ b/configure/xlang/experimental/dockerfile/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-dockerfile -f configure/experimental/dockerfile --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Dockerfile language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Dockerfile language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-dockerfile:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Dockerfile language server to the cluster.
+1. Add the following entry for the Dockerfile language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "dockerfile"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Dockerfile language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/elixir/README.md
+++ b/configure/xlang/experimental/elixir/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-elixir -f configure/experimental/elixir --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Elixir language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Elixir language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-elixir:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Elixir language server to the cluster.
+1. Add the following entry for the Elixir language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "elixir"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Elixir language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/elixir/README.md
+++ b/configure/xlang/experimental/elixir/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-elixir -f configure/experimental/elixir --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Elixir language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_ELIXIR
-       value: tcp://xlang-elixir:8080
-   ```
-
 1. Add the following entry for the Elixir language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "elixir"
+           "language": "elixir",
+           "address": "tcp://xlang-elixir:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Elixir language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Elixir language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/html/README.md
+++ b/configure/xlang/experimental/html/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-html -f configure/experimental/html --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the HTML language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the HTML language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-html:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the HTML language server to the cluster.
+1. Add the following entry for the HTML language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "html"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the HTML language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/html/README.md
+++ b/configure/xlang/experimental/html/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-html -f configure/experimental/html --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the HTML language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_HTML
-       value: tcp://xlang-html:8080
-   ```
-
 1. Add the following entry for the HTML language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "html"
+           "language": "html",
+           "address": "tcp://xlang-html:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the HTML language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the HTML language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/lua/README.md
+++ b/configure/xlang/experimental/lua/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-lua -f configure/experimental/lua --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Lua language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_LUA
-       value: tcp://xlang-lua:8080
-   ```
-
 1. Add the following entry for the Lua language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "lua"
+           "language": "lua",
+           "address": "tcp://xlang-lua:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Lua language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Lua language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/lua/README.md
+++ b/configure/xlang/experimental/lua/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-lua -f configure/experimental/lua --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Lua language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Lua language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-lua:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Lua language server to the cluster.
+1. Add the following entry for the Lua language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "lua"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Lua language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/ocaml/README.md
+++ b/configure/xlang/experimental/ocaml/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-ocaml -f configure/experimental/ocaml --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the OCaml language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the OCaml language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-ocaml:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the OCaml language server to the cluster.
+1. Add the following entry for the OCaml language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "ocaml"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the OCaml language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/ocaml/README.md
+++ b/configure/xlang/experimental/ocaml/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-ocaml -f configure/experimental/ocaml --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the OCaml language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_OCAML
-       value: tcp://xlang-ocaml:8080
-   ```
-
 1. Add the following entry for the OCaml language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "ocaml"
+           "language": "ocaml",
+           "address": "tcp://xlang-ocaml:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the OCaml language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the OCaml language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/r/README.md
+++ b/configure/xlang/experimental/r/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-r -f configure/experimental/r --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the R language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_R
-       value: tcp://xlang-r:8080
-   ```
-
 1. Add the following entry for the R language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "r"
+           "language": "r",
+           "address": "tcp://xlang-r:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the R language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the R language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/r/README.md
+++ b/configure/xlang/experimental/r/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-r -f configure/experimental/r --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the R language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the R language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-r:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the R language server to the cluster.
+1. Add the following entry for the R language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "r"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the R language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/ruby/README.md
+++ b/configure/xlang/experimental/ruby/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-ruby -f configure/experimental/ruby --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Ruby language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Ruby language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-ruby:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Ruby language server to the cluster.
+1. Add the following entry for the Ruby language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "ruby"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`,`base/config-file.ConfigMap.yaml`, and the Ruby language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/ruby/README.md
+++ b/configure/xlang/experimental/ruby/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-ruby -f configure/experimental/ruby --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Ruby language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_RUBY
-       value: tcp://xlang-ruby:8080
-   ```
-
 1. Add the following entry for the Ruby language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "ruby"
+           "language": "ruby",
+           "address": "tcp://xlang-ruby:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`,`base/config-file.ConfigMap.yaml`, and the Ruby language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Ruby language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/rust/README.md
+++ b/configure/xlang/experimental/rust/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-rust -f configure/experimental/rust --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Rust language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Rust language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-rust:8080
    ```
 
-3. Apply your changes to `lsp-proxy` and the Rust language server to the cluster.
+1. Add the following entry for the Rust language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "rust"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Rust language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/experimental/rust/README.md
+++ b/configure/xlang/experimental/rust/README.md
@@ -12,15 +12,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-rust -f configure/experimental/rust --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Rust language server's existence.
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_RUST
-       value: tcp://xlang-rust:8080
-   ```
-
 1. Add the following entry for the Rust language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -30,13 +21,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "rust"
+           "language": "rust",
+           "address": "tcp://xlang-rust:8080"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Rust language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the Rust language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/go/README.md
+++ b/configure/xlang/go/README.md
@@ -15,8 +15,6 @@ You can enable it by:
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
    env:
-     - name: LANGSERVER_GO
-       value: tcp://xlang-go:4389
      - name: LANGSERVER_GO_BG
        value: tcp://xlang-go-bg:4389
    ```
@@ -30,7 +28,8 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "go"
+           "language": "go",
+           "address": "tcp://xlang-go:4389"
          }
        ]
      }

--- a/configure/xlang/go/README.md
+++ b/configure/xlang/go/README.md
@@ -10,7 +10,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-go -f configure/xlang/go/ --recursive >> kubectl-apply-all.sh
    ```
 
-2. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Go language server's existence.
+1. Add the following environment variables to the `lsp-proxy` deployment to make it aware of the Go language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-go-bg:4389
    ```
 
-3. Apply your changes to `lsp-proxy` and the Go language server to the cluster.
+1. Add the following entry for the Go language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "go"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Go language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/java/README.md
+++ b/configure/xlang/java/README.md
@@ -17,8 +17,6 @@ You can enable it by:
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
    env:
-     - name: LANGSERVER_JAVA
-       value: tcp://xlang-java:2088
      - name: LANGSERVER_JAVA_BG
        value: tcp://xlang-java-bg:2088
    ```
@@ -32,7 +30,8 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "java"
+           "language": "java",
+           "address": "tcp://xlang-java:2088"
          }
        ]
      }

--- a/configure/xlang/java/README.md
+++ b/configure/xlang/java/README.md
@@ -12,7 +12,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-java -f configure/xlang/java/ --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Java language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Java language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -23,7 +23,22 @@ You can enable it by:
        value: tcp://xlang-java-bg:2088
    ```
 
-3. Apply your changes to `lsp-proxy` and the Java language server to the cluster.
+1. Add the following entry for the Java language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "java"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Java language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/php/README.md
+++ b/configure/xlang/php/README.md
@@ -10,15 +10,6 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-php -f configure/xlang/php/ --recursive >> kubectl-apply-all.sh
    ```
 
-1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the PHP language server's existence:
-
-   ```yaml
-   # base/lsp-proxy/lsp-proxy.Deployment.yaml
-   env:
-     - name: LANGSERVER_PHP
-       value: tcp://xlang-php:2088
-   ```
-
 1. Add the following entry for the PHP language server to the `langservers` array in your site configuration.
 
    ```yaml
@@ -28,13 +19,14 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "php"
+           "language": "php",
+           "address": "tcp://xlang-php:2088"
          }
        ]
      }
    ```
 
-1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the PHP language server to the cluster.
+1. Apply your changes to `base/config-file.ConfigMap.yaml`, and the PHP language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/php/README.md
+++ b/configure/xlang/php/README.md
@@ -10,7 +10,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-php -f configure/xlang/php/ --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the PHP language server's existence:
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the PHP language server's existence:
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -19,7 +19,22 @@ You can enable it by:
        value: tcp://xlang-php:2088
    ```
 
-3. Apply your changes to `lsp-proxy` and the PHP language server to the cluster.
+1. Add the following entry for the PHP language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "php"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the PHP language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/python/README.md
+++ b/configure/xlang/python/README.md
@@ -10,7 +10,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-python -f configure/xlang/python/ --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Python language server's existence:
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Python language server's existence:
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -21,7 +21,22 @@ You can enable it by:
        value: tcp://xlang-python-bg:2087
    ```
 
-3. Apply your changes to `lsp-proxy` and the Python language server to the cluster.
+1. Add the following entry for the Python language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "python"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Python language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh

--- a/configure/xlang/python/README.md
+++ b/configure/xlang/python/README.md
@@ -15,8 +15,6 @@ You can enable it by:
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
    env:
-     - name: LANGSERVER_PYTHON
-       value: tcp://xlang-python:2087
      - name: LANGSERVER_PYTHON_BG
        value: tcp://xlang-python-bg:2087
    ```
@@ -30,7 +28,8 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "python"
+           "language": "python",
+           "address": "tcp://xlang-python:2087"
          }
        ]
      }

--- a/configure/xlang/typescript/README.md
+++ b/configure/xlang/typescript/README.md
@@ -15,12 +15,8 @@ You can enable it by:
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
    env:
-     - name: LANGSERVER_JAVASCRIPT
-       value: tcp://xlang-typescript:2088
      - name: LANGSERVER_JAVASCRIPT_BG
        value: tcp://xlang-typescript-bg:2088
-     - name: LANGSERVER_TYPESCRIPT
-       value: tcp://xlang-typescript:2088
      - name: LANGSERVER_TYPESCRIPT_BG
        value: tcp://xlang-typescript-bg:2088
    ```
@@ -34,10 +30,12 @@ You can enable it by:
      {
        "langservers": [
          {
-           "language": "javascript"
+           "language": "javascript",
+           "address": "tcp://xlang-typescript:2088"
          },
          {
-           "language": "typescript"
+           "language": "typescript",
+           "address": "tcp://xlang-typescript:2088"
          }
        ]
      }

--- a/configure/xlang/typescript/README.md
+++ b/configure/xlang/typescript/README.md
@@ -10,7 +10,7 @@ You can enable it by:
    echo kubectl apply --prune -l deploy=xlang-typescript -f configure/xlang/typescript/ --recursive >> kubectl-apply-all.sh
    ```
 
-2. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Javascript / Typescript language server's existence.
+1. Adding the following environment variables to the `lsp-proxy` deployment to make it aware of the Javascript / Typescript language server's existence.
 
    ```yaml
    # base/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -25,7 +25,25 @@ You can enable it by:
        value: tcp://xlang-typescript-bg:2088
    ```
 
-3. Apply your changes to `lsp-proxy` and the Javascript / Typescript language server to the cluster.
+1. Add the following entries for the Javascript / Typescript language server to the `langservers` array in your site configuration.
+
+   ```yaml
+   # base/config-file.ConfigMap.yaml
+
+   config.json: |-
+     {
+       "langservers": [
+         {
+           "language": "javascript"
+         },
+         {
+           "language": "typescript"
+         }
+       ]
+     }
+   ```
+
+1. Apply your changes to `lsp-proxy`, `base/config-file.ConfigMap.yaml`, and the Javascript / Typescript language server to the cluster.
 
    ```bash
    ./kubectl-apply-all.sh


### PR DESCRIPTION
This drops the `LANGSERVER_*` environment variables (except the ones ending in `_BG`) in favor of adding entries to the `langservers` array in site config because the Sourcegraph extension corresponding to a language server will not be enabled unless there is an entry for it in the `langservers` array in site config.

The `LANGSERVER_*` environment variables will enable the language server, but not the corresponding Sourcegraph extension.

cc @chrismwendt 