### PR TITLE
helm-legacy: update images to 2.11.3

### DIFF
--- a/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/aws/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: gitserver-1:3178
         - name: VAR
           value: val
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
           value: /data/repos
         - name: VAR
           value: val
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -41,7 +41,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/custom-env-vars/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -41,7 +41,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/gcp/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/manual-storage-class/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/node-selector/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/prometheus/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-exp-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go-bg.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
+++ b/examples/with-langs/generated/sourcegraph/templates/xlang/go/xlang-go.Deployment.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/xlang-go:2.11.2
+        image: sourcegraph/xlang-go:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -54,7 +54,7 @@ spec:
           value: http://localhost:3080
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -44,7 +44,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_APP_URL
           value: http://localhost:3080
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/custom-ls-address/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/frontend/sourcegraph-frontend.Deployment.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: key
               name: tls
-        image: sourcegraph/frontend:2.11.2
+        image: sourcegraph/frontend:2.11.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/github-proxy/github-proxy.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: "true"
         - name: SOURCEGRAPH_CONFIG_FILE
           value: /etc/sourcegraph/config.json
-        image: sourcegraph/github-proxy:2.11.2
+        image: sourcegraph/github-proxy:2.11.3
         name: github-proxy
         ports:
         - containerPort: 3180

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/gitserver/gitserver.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_REPOS_DIR
           value: /data/repos
-        image: sourcegraph/gitserver:2.11.2
+        image: sourcegraph/gitserver:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/indexer/indexer.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/indexer:2.11.2
+        image: sourcegraph/indexer:2.11.3
         name: indexer
         ports:
         - containerPort: 3179

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/lsp-proxy/lsp-proxy.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/lsp-proxy:2.11.2
+        image: sourcegraph/lsp-proxy:2.11.3
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/query-runner/query-runner.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: http://localhost:3080
         - name: TRACKING_APP_ID
           value: "123123123123"
-        image: sourcegraph/query-runner:2.11.2
+        image: sourcegraph/query-runner:2.11.3
         name: query-runner
         ports:
         - containerPort: 3183

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/repo-updater/repo-updater.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           value: /etc/sourcegraph/config.json
         - name: SRC_GIT_SERVERS
           value: gitserver-1:3178
-        image: sourcegraph/repo-updater:2.11.2
+        image: sourcegraph/repo-updater:2.11.3
         name: repo-updater
         ports:
         - containerPort: 3182

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/searcher/searcher.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/searcher:2.11.2
+        image: sourcegraph/searcher:2.11.3
         name: searcher
         ports:
         - containerPort: 3181

--- a/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
+++ b/test-cases/with-jaeger/generated/sourcegraph/templates/symbols/symbols.Deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: sourcegraph/symbols:2.11.2
+        image: sourcegraph/symbols:2.11.3
         name: symbols
         ports:
         - containerPort: 3184

--- a/values.yaml
+++ b/values.yaml
@@ -6,23 +6,23 @@
 # const defines configuration constants that generally should not be changed unless testing out experimental or pre-release features.
 const:
   frontend:
-    image: sourcegraph/frontend:2.11.2
+    image: sourcegraph/frontend:2.11.3
   searcher:
-    image: sourcegraph/searcher:2.11.2
+    image: sourcegraph/searcher:2.11.3
   symbols:
-    image: sourcegraph/symbols:2.11.2
+    image: sourcegraph/symbols:2.11.3
   gitserver:
-    image: sourcegraph/gitserver:2.11.2
+    image: sourcegraph/gitserver:2.11.3
   githubProxy:
-    image: sourcegraph/github-proxy:2.11.2
+    image: sourcegraph/github-proxy:2.11.3
   indexer:
-    image: sourcegraph/indexer:2.11.2
+    image: sourcegraph/indexer:2.11.3
   lspProxy:
-    image: sourcegraph/lsp-proxy:2.11.2
+    image: sourcegraph/lsp-proxy:2.11.3
   queryRunner:
-    image: sourcegraph/query-runner:2.11.2
+    image: sourcegraph/query-runner:2.11.3
   repoUpdater:
-    image: sourcegraph/repo-updater:2.11.2
+    image: sourcegraph/repo-updater:2.11.3
   indexedSearch:
     image: sourcegraph/zoekt:18-05-30_3d2275e
   pgsql:
@@ -31,7 +31,7 @@ const:
   syntectServer:
     image: sourcegraph/syntect_server:624a1a2
   xlangGo:
-    image: sourcegraph/xlang-go:2.11.2
+    image: sourcegraph/xlang-go:2.11.3
   xlangJava:
     image: sourcegraph/xlang-java-skinny:2018-05-10-1621
   xlangJavascriptTypescript:


### PR DESCRIPTION
`2.11.3` contains a backported version of `repo-updater` which includes https://github.com/sourcegraph/sourcegraph/commit/ccd21d3185ab57115232014ac3491ef42e243db2