### PR TITLE
Fix verification instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -53,13 +53,13 @@
    kubectl 1.9.x:
 
    ```bash
-   kubectl port-forward $(kubectl get pod -l app=sourcegraph-frontend -o template --template="{{(index .items 0).metadata.name}}") 30080:3080
+   kubectl port-forward $(kubectl get pod -l app=sourcegraph-frontend -o template --template="{{(index .items 0).metadata.name}}") 3080
    ```
 
    kubectl 1.10.0 or later:
 
    ```
-   kubectl port-forward svc/sourcegraph-frontend 30080
+   kubectl port-forward svc/sourcegraph-frontend 3080:30080
    ```
 
    Open http://localhost:30080 in your browser and you will see a setup page. Congrats, you have Sourcegraph up and running!


### PR DESCRIPTION
The default appURL is localhost:3080 and now that `canonicalURLRedirect` defaults to true these instructions didn't work because the local port needs to be 3080 instead of 30080.