### PR TITLE
Remove liveness check for sourcegraph-frontend

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,13 +58,6 @@ spec:
         #       key: key
         #       name: tls
         image: sourcegraph/frontend:2.13.2@sha256:66ecfcdf900468aec7c63f3d4cbf5b86c24769eedfdf4096b1506d8bff65e460
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
         name: frontend
         ports:
         - containerPort: 3080


### PR DESCRIPTION
Somewhere between 2.12.3 and 2.13.0 the frontend healthcheck started failing. I have not debugged further why yet, but this is a quick fix.