### PR TITLE
management-console: set max unavailable to 1

### DIFF
--- a/base/management-console/management-console.Deployment.yaml
+++ b/base/management-console/management-console.Deployment.yaml
@@ -16,7 +16,7 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
If `maxUnavailable` is set to 0, then the deployment can never be updated since the old pod will never release its claim on the `management-console` PVC. 

We set `maxUnavailable` to `1` in other stateful services like pgsql:

https://github.com/sourcegraph/deploy-sourcegraph/blob/c01dfc624b8e8072c89e6c9ae4c5404d3368eb64/base/pgsql/pgsql.Deployment.yaml#L16-L20

cc @slimsag