### PR TITLE
Exclude raw route from page load latency alert

### DIFF
--- a/configure/prometheus/prometheus.ConfigMap.yaml
+++ b/configure/prometheus/prometheus.ConfigMap.yaml
@@ -22,7 +22,7 @@ data:
       }
 
     ALERT ProdPageLoadLatency
-      IF histogram_quantile(0.9, sum(rate(src_http_request_duration_seconds_bucket{job="sourcegraph-frontend"}[10m])) by (le)) > 20
+      IF histogram_quantile(0.9, sum(rate(src_http_request_duration_seconds_bucket{job="sourcegraph-frontend", route!="raw"}[10m])) by (le)) > 20
       LABELS { severity="page" }
       ANNOTATIONS {
         summary = "High page load latency",


### PR DESCRIPTION
It isn't expected to perform with the same latency as interactive endpoints.