### PR TITLE
redis-store: revert pure-docker simplifications

### DIFF
--- a/base/redis/redis-store.ConfigMap.yaml
+++ b/base/redis/redis-store.ConfigMap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  redis.conf: |
+    # allow access from all instances
+    protected-mode no
+
+    # limit memory usage, return error when hitting limit
+    maxmemory 5gb
+    maxmemory-policy noeviction
+
+    # live commit log to disk, additionally snapshots every 10 minutes
+    dir /redis-data/
+    appendonly yes
+    save 600 1
+kind: ConfigMap
+metadata:
+  labels:
+    deploy: sourcegraph
+  name: redis-store

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,8 +24,10 @@ spec:
         app: redis-store
     spec:
       containers:
-      - env:
-        image: sourcegraph/redis-store:18-10-28_e45f6d82@sha256:1fe101e1f04a8e267fda85c342cd3b974ab4a9e47718b864752f14f1da51579c
+      - command:
+        - redis-server
+        - /etc/redis/redis.conf
+        image: sourcegraph/redis:18-02-07_8205764_3.2-alpine@sha256:f2957e0973ef16968d4bfacfae5ab08da985257aa7ce358a85152275e3da78e8
         livenessProbe:
           initialDelaySeconds: 30
           tcpSocket:
@@ -48,6 +50,9 @@ spec:
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data
+        - mountPath: /etc/redis
+          name: config
+          readOnly: true
       - image: sourcegraph/redis_exporter:18-02-07_bb60087_v0.15.0@sha256:282d59b2692cca68da128a4e28d368ced3d17945cd1d273d3ee7ba719d77b753
         name: redis-exporter
         ports:
@@ -66,3 +71,6 @@ spec:
       - name: redis-data
         persistentVolumeClaim:
           claimName: redis-store
+      - configMap:
+          name: redis-store
+        name: config


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/1761

This PR reverts the redis-store changes in 45a9fedca3e4031bf5d33a792868f277a13965df, which makes the redis-store deplyoment healthy again. 