### PR TITLE
frontend: Add readinessProbe

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -55,6 +55,13 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
         name: frontend
         ports:
         - containerPort: 3080


### PR DESCRIPTION
On container startup the container will not instantly be marked as Ready, but
rather be Unready. Every 5 seconds we will attempt the probe and will only
mark the container as Ready once it passes. If we are Ready, it will take 3
failures to be marked as Unready.

Unready containers do not receive traffic. This check should prevent bad
config/images rolling out.

Before this change we would only start doinng livenessProbes after a minute,
so would not catch those issues.

Learn more at https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes

Fixes https://github.com/sourcegraph/sourcegraph/issues/1902