### PR TITLE
gitserver, postgres, redis: resource requests == resource limits

### DIFF
--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -39,8 +39,8 @@ spec:
             cpu: "4"
             memory: 8G
           requests:
-            cpu: 500m
-            memory: 1G
+            cpu: "4" 
+            memory: 8G
         volumeMounts:
         - mountPath: /data/repos
           name: repos

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -40,8 +40,8 @@ spec:
             cpu: "4"
             memory: 2Gi
           requests:
-            cpu: 250m
-            memory: 1G
+            cpu: "4" 
+            memory: 2Gi
         volumeMounts:
         - mountPath: /data
           name: disk

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -43,8 +43,8 @@ spec:
             cpu: "1"
             memory: 6Gi
           requests:
-            cpu: 250m
-            memory: 500M
+            cpu: "1" 
+            memory: 6Gi
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -45,8 +45,8 @@ spec:
             cpu: "1"
             memory: 6Gi
           requests:
-            cpu: 250m
-            memory: 500M
+            cpu: "1" 
+            memory: 6Gi
         volumeMounts:
         - mountPath: /redis-data
           name: redis-data


### PR DESCRIPTION
gitserver, redis, and pgsql represent single points of failure for a Sourcegraph instance. If those services go down, then your sourcegraph.com will be unavailable / experience major issues. 

By setting `resource.requests=resource.limits` for each container in a pod, [the pod's QoS class is considered "guaranteed"](https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6), which means that K8s will kill all other services before these pods if the node is resource constrained. 

