### PR TITLE
pgsql: Use smarter readiness and liveness probes

### DIFF
--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - env:
-        image: sourcegraph/postgres-11.1:19-01-29_e6088853@sha256:00ca8c80a259452f5faa8aa0ddc51a2ee1a7b5b0a4e61357b22588e9d6bd8d23
+        image: sourcegraph/postgres-11.1:19-01-30_3d7f09aa@sha256:6d47f2fbc71b2a24869920fe9c9ad579dab616b37ad5e8b3ab5beb33d9a85cfe
         readinessProbe:
           exec:
             command:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -26,11 +26,16 @@ spec:
     spec:
       containers:
       - env:
-        image: sourcegraph/postgres-11.1:19-01-14_0d5c7d60@sha256:8d815c4b42ad0d9f076fb01a1a6c709e197b03f83350088b34b6aa17a6e8be36
+        image: sourcegraph/postgres-11.1:19-01-29_e6088853@sha256:00ca8c80a259452f5faa8aa0ddc51a2ee1a7b5b0a4e61357b22588e9d6bd8d23
+        readinessProbe:
+          exec:
+            command:
+              - /ready.sh
         livenessProbe:
           initialDelaySeconds: 15
-          tcpSocket:
-            port: 5432
+          exec:
+            command:
+              - /liveness.sh
         name: pgsql
         ports:
         - containerPort: 5432


### PR DESCRIPTION
Our pgsql image automatically upgrades from 9.4 to 11.1. However, this can be a
slow process leading to the liveness probe killing the pod before the migration
is finished. Our image now embeds scripts to check the liveness and readiness:

- readiness checks if postgres is available via TCP us pg_isready
- liveness passes if we are upgrading. Otherwise it uses the readiness check.

This should also fix the postgres log spam about bad TCP clients, since we are
removing the dumb TCP probe we used to have.

Part of https://github.com/sourcegraph/sourcegraph/issues/1404