### PR TITLE
Revert Postgres to 9.4 for the 3.0 release

### DIFF
--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - env:
-        image: sourcegraph/postgres-11.1:19-01-14_0d5c7d60@sha256:8d815c4b42ad0d9f076fb01a1a6c709e197b03f83350088b34b6aa17a6e8be36
+        image: sourcegraph/postgres:18-11-26_9.4_a9463ecc@sha256:ca9964a200beb9756704279f82f13caea39eaee8ee9e9e13eba57f2de4952f71
         livenessProbe:
           initialDelaySeconds: 15
           tcpSocket:
@@ -40,7 +40,7 @@ spec:
             cpu: "4"
             memory: 2Gi
           requests:
-            cpu: "4" 
+            cpu: "4"
             memory: 2Gi
         volumeMounts:
         - mountPath: /data

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -26,16 +26,11 @@ spec:
     spec:
       containers:
       - env:
-        image: sourcegraph/postgres-11.1:19-01-30_3d7f09aa@sha256:6d47f2fbc71b2a24869920fe9c9ad579dab616b37ad5e8b3ab5beb33d9a85cfe
-        readinessProbe:
-          exec:
-            command:
-              - /ready.sh
+        image: sourcegraph/postgres-11.1:19-01-14_0d5c7d60@sha256:8d815c4b42ad0d9f076fb01a1a6c709e197b03f83350088b34b6aa17a6e8be36
         livenessProbe:
           initialDelaySeconds: 15
-          exec:
-            command:
-              - /liveness.sh
+          tcpSocket:
+            port: 5432
         name: pgsql
         ports:
         - containerPort: 5432

--- a/docs/sourcegraph-3.0.migrate.md
+++ b/docs/sourcegraph-3.0.migrate.md
@@ -13,9 +13,3 @@ Sourcegraph 3.0 removed lsp-proxy and automatic language server deployment in fa
 Sourcegraph 3.0 removed HTTPS / TLS features from Sourcegraph in favor of relying on [Kubernetes Ingress Resources](https://kubernetes.io/docs/concepts/services-networking/ingress/). As a consequence, Sourcegraph 3.0 does not expose TLS as the NodePort 30433. Instead you need to ensure you have setup and configured an ingress controller. See [ingress controller documentation](configure.md#ingress-controller-recommended) and [configure TLS/SSL documentation](configure.md#configure-tlsssl).
 
 If you previously configured `TLS_KEY` and `TLS_CERT` environment variables, you can remove them from [base/frontend/sourcegraph-frontend.Deployment.yaml](../base/frontend/sourcegraph-frontend.Deployment.yaml)
-
-## Postgres 11.1
-
-Sourcegraph 3.0 has been upgraded to work with Postgres 11.1 (from 9.4). Follow the below upgrade procedure before deploying Sourcegraph 3.0.
-
-**To be written.**


### PR DESCRIPTION
This commit reverts back from the 11.1 Postgres version since we couldn't finish everything in time.

Follow up: https://github.com/sourcegraph/sourcegraph/issues/1404#issuecomment-459900259

