### PR TITLE
Have renovate automatically update to release candidates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
         "^sourcegraph/"
       ],
       "groupName": "Sourcegraph Docker images",
-      "ignoreUnstable": true,
+      "ignoreUnstable": false,
       "semanticCommits": false,
       "reviewers": [
         "ggilmore"

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
         "^sourcegraph/"
       ],
       "groupName": "Sourcegraph Docker images",
+      "ignoreUnstable": true,
       "semanticCommits": false,
       "reviewers": [
         "ggilmore"


### PR DESCRIPTION
This makes testing easier and is ok because our releases are tagged.

https://renovatebot.com/docs/configuration-options/#ignoreunstable