### PR TITLE
Delay frontend liveness check to 5 minutes

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -63,7 +63,7 @@ spec:
             path: /healthz
             port: http
             scheme: HTTP
-          initialDelaySeconds: 60
+          initialDelaySeconds: 300
           timeoutSeconds: 5
         readinessProbe:
           httpGet:


### PR DESCRIPTION
The frontend requires other services to be running, so it needlessly enters CrashLoopBackoff during normal startup.