### PR TITLE
Use semver versionScheme for sourcegraph images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,8 @@
         "^sourcegraph/"
       ],
       "groupName": "Sourcegraph Docker images",
+      "versionScheme": "semver",
       "ignoreUnstable": false,
-      "unstablePattern": ".*-rc.*",
       "semanticCommits": false,
       "reviewers": [
         "ggilmore"


### PR DESCRIPTION
This tells Renovate to assume semver-compatible versioning for all sourcegraph images. By default Renovate assumes typical Dockerish versions, where the suffix is related to platform (e.g. `3.1.0-alpine` and not semver-like (e.g. `3.1.0-rc.3`).