### PR TITLE
add category:rbac label

### DIFF
--- a/base/frontend/sourcegraph-frontend.Role.yaml
+++ b/base/frontend/sourcegraph-frontend.Role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
+    category: rbac
     deploy: sourcegraph
   name: sourcegraph-frontend
 rules:

--- a/base/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/base/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    category: rbac
     deploy: sourcegraph
   name: sourcegraph-frontend
 roleRef:

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -4,5 +4,6 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   labels:
+    category: rbac
     deploy: sourcegraph
   name: sourcegraph-frontend

--- a/configure/prometheus/prometheus.ClusterRole.yaml
+++ b/configure/prometheus/prometheus.ClusterRole.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    category: rbac
     deploy: prometheus
   name: prometheus
 rules:

--- a/configure/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/configure/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
+    category: rbac
     deploy: prometheus
   name: prometheus
 roleRef:

--- a/configure/ssd/pod-tmp-gc.ClusterRole.yaml
+++ b/configure/ssd/pod-tmp-gc.ClusterRole.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    category: rbac
     deploy: pod-tmp-gc
   name: pod-tmp-gc
 rules:

--- a/configure/ssd/pod-tmp-gc.ClusterRoleBinding.yaml
+++ b/configure/ssd/pod-tmp-gc.ClusterRoleBinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
+    category: rbac
     deploy: pod-tmp-gc 
   name: pod-tmp-gc
 roleRef:


### PR DESCRIPTION
Deploying [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) manifests to a Kubernetes cluster might require elevated permissions (which could be undesirable in some CD scenarios).

This PR adds a `category: rbac` label to all RBAC manifests. This makes it possible to possible [to exclude these manifests](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) from certain `kubectl` operations (e.g `-l deploy=sourcegraph,category!=rbac)