### PR TITLE
Minimum required k8s version is 1.9

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 
-- [Kubernetes](https://kubernetes.io/) v1.8.7 or later
+- [Kubernetes](https://kubernetes.io/) v1.9 or later
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.9.7 or later
 - Access to server infrastructure on which you can create a Kubernetes cluster (see
   [resource allocation guidelines](scale.md)).


### PR DESCRIPTION
We rely on StatefulSets which became GA in 1.9. A customer just experienced an issue when attempting to deploy to a 1.8.7 cluster.

https://sourcegraph.slack.com/archives/C07KZF47K/p1551220913135300