### PR TITLE
Do not specify PG* envvars in repo-updater

### DIFF
--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -27,14 +27,6 @@ spec:
       containers:
       - image: sourcegraph/repo-updater:3.2.2@sha256:5b8a3d31405e0cd5f7343a0ee6453fc31ad50e0e511d5147a836db9989daae94
         env:
-        - name: PGHOST
-          value: pgsql
-        - name: PGPORT
-          value: "5432"
-        - name: PGSSLMODE
-          value: disable
-        - name: PGUSER
-          value: sg
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
         ports:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -35,8 +35,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        - name: PGDATABASE
-          value: sg
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
         ports:


### PR DESCRIPTION
Since https://github.com/sourcegraph/sourcegraph/pull/3346 repo-updater relies on the ServiceConnections config it fetches from the frontend. Now admins do not need to configure multiple deployments when updating PG settings.

Part of https://github.com/sourcegraph/sourcegraph/issues/2025