### PR TITLE
lang-go: fix default secret-name

### DIFF
--- a/configure/lang/go/lang-go.Ingress.yaml
+++ b/configure/lang/go/lang-go.Ingress.yaml
@@ -30,7 +30,7 @@ spec:
       # Make sure to replace 'go.sourcegraph.example.com' with the real domain that you are
       # using for the Go language server.
       - go.sourcegraph.example.com
-      secretName: sourcegraph-tls
+      secretName: go-tls
     rules:
     - host: go.sourcegraph.example.com
       http:


### PR DESCRIPTION
The tls secret for lang-go should be separate from the one that you use for `sourcegraph.example.com` since lang-go needs to be deployed under a different hostname. 