### PR TITLE
add back default host for sourcegraph-frontend ingress

### DIFF
--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -20,10 +20,12 @@ spec:
   #   - sourcegraph.example.com
   #   secretName: sourcegraph-tls
   rules:
-  - host: sourcegraph.example.com
-    http:
+  - http:
       paths:
       - path: /
         backend:
           serviceName: sourcegraph-frontend
           servicePort: 30080
+    # If you're using TLS/SSL, uncommenent the following line and replace 'sourcegraph.example.com' with the real
+    # domain that you want to use for your Sourcegraph instance.
+    # host: sourcegraph.example.com

--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -26,6 +26,6 @@ spec:
         backend:
           serviceName: sourcegraph-frontend
           servicePort: 30080
-    # If you're using TLS/SSL, uncommenent the following line and replace 'sourcegraph.example.com' with the real
+    # If you're using TLS/SSL, uncomment the following line and replace 'sourcegraph.example.com' with the real
     # domain that you want to use for your Sourcegraph instance.
     # host: sourcegraph.example.com


### PR DESCRIPTION
In https://github.com/sourcegraph/deploy-sourcegraph/pull/230, I removed the default wildcard handler for sourcegraph-frontend.Ingress.yaml for the following reasons: 

1. Specifying a `host` is required if you're using TLS with an Ingress definition
1. Every customer is probably going to use https
1. Using TLS/SSL for `'sourcegraph.example.com'` (your instance) is required for secure communication with language servers

However, this can lead to confusing behavior when we spin up a test instance of sourcegraph. If you're just connecting to the instance via the load balancer's ip address (and not adding an /etc/hosts entry or provisioning a domain name), those requests won't get forwarded to the `sourcegraph-frontend` service since sourcegraph-frontend.Ingress.yaml is expecting a specific hostname. 

This PR adds back the default wildcard handler, and instead documents the need to specify the `host` in the comments for sourcegraph-frontend.Ingress.yaml and in docs/configure.md