### PR TITLE
Update documentation for Typescript language server deployment

### DIFF
--- a/configure/lang/typescript/README.md
+++ b/configure/lang/typescript/README.md
@@ -4,7 +4,7 @@ This folder contains the deployment manifests for the [Javascript/Typescript lan
 
 ## Installation instructions
 
-### Setup TLS/SSL 
+### Setup TLS/SSL (Highly recommended, optional)
 
 TLS/SSL is required for secure communication with the language server. Once you have completed ["Configure TLS/SSL"](../../../docs/configure.md#configure-tlsssl) in [docs/configure.md](../../../docs/configure.md#configure-tlsssl), for your overall Sourcegraph instance, you'll need to configure TLS/SSL for the Javascript/Typescript language server as well. 
 
@@ -43,7 +43,7 @@ The Javascript/Typescript language server needs it's own domain (e.g. `typescrip
 **WARNING:** Do NOT commit the actual TLS cert and key files to your fork (unless your fork is
 private **and** you are okay with storing secrets in it).
 
-### HTTP basic authentication
+### HTTP basic authentication (Highly recommended, optional)
 
 HTTP basic authentication is used to prevent unauthorized access to the language server. At a high level, you'll create a secret then put it in both [configure/lang/typescript/lang-typescript.Ingress.yaml](lang-typescript.Ingress.yaml) and in your Sourcegraph global settings so that logged-in users are authenticated when their browser makes requests to the Javascript/Typescript language server.
 
@@ -76,13 +76,6 @@ _These instructions are derived from https://kubernetes.github.io/ingress-nginx/
    echo kubectl create secret generic langserver-auth --from-file=auth >> create-new-cluster.sh
    ```
 
-1. Add the following fields to your Sourcegraph global settings (`$PASSWORD` is that password that you created above, and `$TYPESCRIPT_DOMAIN_NAME` is the domain name that you are using for your Javascript/Typescript language server instance):
-
-    ```js
-    "typescript.serverUrl": "wss://langserveruser:$PASSWORD@$TYPESCRIPT_DOMAIN_NAME/",
-    "typescript.sourcegraphUrl": "http://sourcegraph-frontend:30080",
-    ```
-
 ### Apply the Javascript/Typescript language server configuration to the cluster
 
 1. Add the `kubectl` command that applies the Javascript/Typescript language server configuration to [kubectl-apply-all.sh](../../../kubectl-apply-all.sh)
@@ -96,3 +89,32 @@ _These instructions are derived from https://kubernetes.github.io/ingress-nginx/
     ```console
     ./kubectl-apply-all.sh
     ```
+
+### Configure Sourcegraph to use the Typescript language server
+
+Add the following fields to your Sourcegraph global settings (`$PASSWORD` is the HTTP basic auth password that you created above, and `$TYPESCRIPT_DOMAIN_NAME` is the domain name that you are using for your Typescript language server instance):
+
+```js
+"typescript.serverUrl": "wss://langserveruser:$PASSWORD@$TYPESCRIPT_DOMAIN_NAME/",
+"typescript.sourcegraphUrl": "http://sourcegraph-frontend:30080",
+```
+
+If you haven't setup SSL/TLS and HTTP basic authentication yet `typescript.serverUrl` should look like this:
+
+```js
+"typescript.serverUrl": "ws://$TYPESCRIPT_DOMAIN_NAME"
+```
+
+Note that `wss` has been changed to `ws`.
+
+If you choose not to expose the language server to the internet yet, you need to forward a local port to the language server so that your browser can connect to it:
+
+```console
+kubectl port-forward svc/lang-typescript 9876:8080
+```
+
+Then your `typescript.serverUrl` would look like this:
+
+```js
+"typescript.serverUrl": "ws://localhost:9876"
+```


### PR DESCRIPTION
After I merged #244 I noticed that the Typescript docs use the exact same structure, so this PR here  takes the changes made to the Go lang server documentation in PR #244 and adapts them for the Typescript language server