### PR TITLE
update prometheus cluster role so it can provide node metrics

### DIFF
--- a/configure/prometheus/prometheus.ClusterRole.yaml
+++ b/configure/prometheus/prometheus.ClusterRole.yaml
@@ -9,10 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  - services
   - endpoints
+  - namespaces
+  - nodes
+  - nodes/metrics
+  - nodes/proxy
   - pods
+  - services
   verbs:
   - get
   - list


### PR DESCRIPTION
A customer applied this patch to their Prometheus cluster role so they could use https://github.com/braedon/prometheus-es-exporter