### PR TITLE
update zoekt-webserver to include indexed multiline fix

### DIFF
--- a/base/indexed-search/indexed-search.Deployment.yaml
+++ b/base/indexed-search/indexed-search.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: sourcegraph/zoekt-webserver:19-06-13_f4122ec@sha256:d2403ea56e85a327a1cad1ab93710628c1b3d03689a14574b92278dae871d838
+        image: sourcegraph/zoekt-webserver:19-06-19_c84cd19@sha256:57a3eb4991540bf813fc62459719b2db3dbac540dd284088cd2e84081225531f
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:


### PR DESCRIPTION
This brings in https://github.com/sourcegraph/zoekt/pull/8.