### PR TITLE
base/syntect-server: increase memory from 512 MB -> 4 GB

### DIFF
--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -44,9 +44,9 @@ spec:
         resources:
           limits:
             cpu: "4"
-            memory: 512M
+            memory: 4G
           requests:
             cpu: 250m
-            memory: 512M
+            memory: 2G
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
Various deployments we have show that with some languages syntect_server
consumes more memory and OOMs. Bumping this up to 4 GB makes sense and
has worked well in customer deployments that previously had issues.