### PR TITLE
Add lsif-server

### DIFF
--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -65,4 +65,5 @@ spec:
         runAsUser: 0
       volumes:
       - name: lsif-storage
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: lsif-server

--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: LSIF HTTP server for code intelligence.
+  labels:
+    deploy: sourcegraph
+  name: lsif-server
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: lsif-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: lsif-server
+    spec:
+      containers:
+      - env:
+        - name: LSIF_STORAGE_ROOT
+          value: /lsif-storage
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: index.docker.io/sourcegraph/lsif-server@sha256:a19bc9e24cc86fa2c9656f1fcff532a5dce07739b6dcfe2b2503ba170e0593ff
+        terminationMessagePolicy: FallbackToLogsOnError
+        name: lsif-server
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 3186
+          name: http
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2G
+          requests:
+            cpu: 500m
+            memory: 500M
+        volumeMounts:
+        - mountPath: /lsif-storage
+          name: lsif-storage
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: lsif-storage
+        emptyDir: {}

--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/lsif-server@sha256:a19bc9e24cc86fa2c9656f1fcff532a5dce07739b6dcfe2b2503ba170e0593ff
+        image: index.docker.io/sourcegraph/lsif-server:3.6.0-rc.2@sha256:8026dc7cdb91e942ecfd3261d788a73f951c0ffb5735aed7566a8ab60afac39a
         terminationMessagePolicy: FallbackToLogsOnError
         name: lsif-server
         livenessProbe:

--- a/base/lsif-server/lsif-server.PersistentVolumeClaim.yaml
+++ b/base/lsif-server/lsif-server.PersistentVolumeClaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    deploy: sourcegraph
+  name: lsif-server
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: sourcegraph

--- a/base/lsif-server/lsif-server.Service.yaml
+++ b/base/lsif-server/lsif-server.Service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: lsif-server
+    deploy: sourcegraph
+  name: lsif-server
+spec:
+  ports:
+  - name: http
+    port: 3186
+    targetPort: http
+  selector:
+    app: lsif-server
+  type: ClusterIP


### PR DESCRIPTION
This adds lsif-server that was introduced in https://github.com/sourcegraph/sourcegraph/pull/4799

lsif-server is a service that sits behind Sourcegraph's frontend and exposes an HTTP API that receives file uploads and stores them on disk. That storage is expected to stick around for the lifetime of the Sourcegraph instance.

TODO

- [x] Add the 3.6 image tag
- [x] Set up a persistent volume (@sourcegraph/distribution could anyone help me with this?)