### PR TITLE
Update Sourcegraph Docker images Docker tags to v3.5.4

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -48,7 +48,7 @@ spec:
         # archives of repositories at a commit.
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/frontend:3.5.2@sha256:d987eac17cb83892be582cf83c4f4a1e514f2ac4985ba633a919105205f1a9b9
+        image: index.docker.io/sourcegraph/frontend:3.5.4@sha256:6e425966190421aba3bcfd25532d2eae927c0648e6e52ce5f9e7dcf3f7c4620e
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.5.2@sha256:03b61f3402dabfbbee95fc0af9cd6f46d777a7cb130220b20af5f02fc6e10f82
+        image: index.docker.io/sourcegraph/github-proxy:3.5.4@sha256:6e425966190421aba3bcfd25532d2eae927c0648e6e52ce5f9e7dcf3f7c4620e
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.5.2@sha256:1be5075f374427b3b627a27ae782e21633c7efa7f82f44000873ceaa99f57412
+        image: index.docker.io/sourcegraph/gitserver:3.5.4@sha256:350bcc60a965bf440a63cf4fa3fb6bd636ad23d267fc903dc3c114d67ec1b0dd
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5

--- a/base/management-console/management-console.Deployment.yaml
+++ b/base/management-console/management-console.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        image: index.docker.io/sourcegraph/management-console:3.5.2@sha256:8f0c1fcc5b4665a31dc2448b3204c9eb48487e4e113fb6184fbda795940bd10a
+        image: index.docker.io/sourcegraph/management-console:3.5.4@sha256:dd887f702c184dc9ee2e063cd5dc4caab27a9fbe0cf407240a8d66579c7ac773
         terminationMessagePolicy: FallbackToLogsOnError
         name: management-console
         ports:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.5.2@sha256:bcaef85fd6cb640abacaef8b03ad81051e26538164cab8e659c3fc35fb1b222d
+        image: index.docker.io/sourcegraph/query-runner:3.5.4@sha256:8f19fc2a3f54876bf91710932608c95061fd68795809f4fc93ed3f03ba523c13
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.5.2@sha256:fce45b4aaf33d93a4e1730890c6f6747c129210e4db93efe29b6c0624d243578
+      - image: index.docker.io/sourcegraph/repo-updater:3.5.4@sha256:a21bdef35dc729f5bceb265d5d63a35f36bf1443668ee51fd8484630e34b8324
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.5.2@sha256:ee25c0357de04b598b44cdc6faa3a8e701e64b552bcdc07b06eb78aaf6150fdb
+        image: index.docker.io/sourcegraph/searcher:3.5.4@sha256:3632f2797de64d586de928a4eaef259f4d5f6c06faac9fc331202b8e8b767c24
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.5.2@sha256:f40c85c833477ad6057c46e999777f45ba155c7cd269a7bad2051991768790af
+        image: index.docker.io/sourcegraph/symbols:3.5.4@sha256:3faeeecbdbb2ecef1eb1b58c44f50ce1c6d6ef3d0a09e164ac2eea973e111c71
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:


### PR DESCRIPTION
After waiting on renovate bot for an hour I decided to do this by hand by collecting the SHAs from the build output in this build:

https://buildkite.com/sourcegraph/sourcegraph/builds/40709#aa8f45c0-b4e6-481c-bb91-c4e8335fc4de