### PR TITLE
update aws scaling docs

### DIFF
--- a/docs/k8s.eks.md
+++ b/docs/k8s.eks.md
@@ -53,12 +53,9 @@ Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/us
 
 | Users        | Instance type | Min nodes | Max nodes | Cost est.  | Attached Storage | Root Storage |
 | ------------ | ------------- | --------- | --------- | ---------- | ---------------- | ------------ |
-| 10-25        | t2.xlarge     | 4         | 6         | $18-27/day | 500 GB           | 50 GB        |
-| 25-500       | t2.xlarge     | 5         | 8         | $22-36/day | 500 GB           | 50 GB        |
-| 500-2,000    | t2.xlarge     | 6         | 8         | $27-36/day | 500 GB           | 50 GB        |
-| 2,000-4,000  | t2.xlarge     | 8         | 10        | $36-45/day | 900 GB           | 50 GB        |
-| 4,000-10,000 | t2.xlarge     | 12        | 14        | $53-62/day | 900 GB           | 50 GB        |
-| 10,000+      | t2.2xlarge    | 8         | 10        | $71-89/day | 900 GB           | 50 GB        |
+| 10-25        | m5.4xlarge    | 4         | 7         | $80-137/day | 500 GB           | 100 GB        |
+| 25-500       | m5.4xlarge   | 6         | 10         | $118-195/day | 500 GB           | 100 GB        |
+
 
 </div>
 

--- a/docs/k8s.eks.md
+++ b/docs/k8s.eks.md
@@ -53,8 +53,8 @@ Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/us
 
 | Users        | Instance type | Min nodes | Max nodes | Cost est.  | Attached Storage | Root Storage |
 | ------------ | ------------- | --------- | --------- | ---------- | ---------------- | ------------ |
-| 10-25        | m5.4xlarge    | 4         | 7         | $80-137/day | 500 GB           | 100 GB        |
-| 25-500       | m5.4xlarge   | 6         | 10         | $118-195/day | 500 GB           | 100 GB        |
+| 10-500        | m5.4xlarge    | 3         | 6         | $59-118/day | 500 GB           | 100 GB        |
+| 500-2000       | m5.4xlarge   | 6         | 10         | $118-195/day | 500 GB           | 100 GB        |
 
 
 </div>

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -24,8 +24,8 @@ table.
     <th colspan="3">Compute nodes</th>
   </tr>
   <tr><th>Provider</th><th>Node type</th><th>Boot/ephemeral disk size</th></tr>
-  <tr><td><a href="/docs/k8s.eks.md">Amazon EKS (better than plain EC2)</a> </td><td>t2.xlarge</td><td>N/A</td></tr>
-  <tr><td><a href="https://kubernetes.io/docs/getting-started-guides/aws/">AWS EC2</a></td><td>m4.4xlarge</td><td>N/A</td></tr>
+  <tr><td><a href="/docs/k8s.eks.md">Amazon EKS (better than plain EC2)</a> </td><td>m5.4xlarge</td><td>N/A</td></tr>
+  <tr><td><a href="https://kubernetes.io/docs/getting-started-guides/aws/">AWS EC2</a></td><td>m5.4xlarge</td><td>N/A</td></tr>
   <tr><td><a href="https://cloud.google.com/kubernetes-engine/docs/quickstart">Google Kubernetes Engine (GKE)</a></td><td>n1-standard-16</td><td>100 GB (default)</td></tr>
   <tr><td><a href="/docs/k8s.azure.md">Azure</a> </td><td>D16 v3</td><td>100 GB (SSD preferred)</td></tr>
   <tr><td><a href="https://kubernetes.io/docs/setup/pick-right-solution/">Other</a></td><td>16 vCPU, 60 GiB memory per node</td><td>100 GB (SSD preferred)</td></tr>


### PR DESCRIPTION
- t2.xlarge only has 4 CPU cores. Some of our services require 6 cores (e.g. postgres, zoekt), so these nodes are insufficient. 

- Some quick calculations show that we need ~30 cores and ~26G RAM just for all of our services in `base/`

- `m5.4xlarge` is close to the machine type what we're using for sourcegraph.com (`n1-standard-16` - `16 cores and 60 gigs of ram`)

- k8s has a roughly equal packing (~30% requested CPU) when we use 4 `m5.4xlarge` nodes for the base deployment (no tuning)