### PR TITLE
avoid privileged ports

### DIFF
--- a/base/grafana/grafana.ConfigMap.yaml
+++ b/base/grafana/grafana.ConfigMap.yaml
@@ -7,7 +7,7 @@ data:
       - name: Prometheus
         type: prometheus
         access: proxy
-        url: http://prometheus:80
+        url: http://prometheus:30090
         isDefault: true
         editable: false
 kind: ConfigMap

--- a/base/grafana/grafana.Service.yaml
+++ b/base/grafana/grafana.Service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 80
+    port: 30070
     targetPort: http
   selector:
     app: grafana

--- a/base/prometheus/prometheus.Service.yaml
+++ b/base/prometheus/prometheus.Service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 80
+    port: 30090
     targetPort: http
   selector:
     app: prometheus


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/5536

avoid requiring elevated permissions for privileged ports.

see:

**https://stackoverflow.com/questions/53775328/kubernetes-port-forwarding-error-listen-tcp4-127-0-0-188-bind-permission-de/55023272#55023272**