### PR TITLE
Update lsif-server deployment to support worker metrics.

### DIFF
--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -36,21 +36,23 @@ spec:
         name: lsif-server
         livenessProbe:
           httpGet:
-            path: /ping
-            port: http
+            path: /healthz
+            port: server
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /ping
-            port: http
+            path: /healthz
+            port: server
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5
         ports:
         - containerPort: 3186
-          name: http
+          name: server
+        - containerPort: 3187
+          name: worker
         resources:
           limits:
             cpu: "2"

--- a/base/lsif-server/lsif-server.Service.yaml
+++ b/base/lsif-server/lsif-server.Service.yaml
@@ -7,9 +7,12 @@ metadata:
   name: lsif-server
 spec:
   ports:
-  - name: http
+  - name: server
     port: 3186
-    targetPort: http
+    targetPort: server
+  - name: worker
+    port: 3187
+    targetPort: worker
   selector:
     app: lsif-server
   type: ClusterIP

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -472,12 +472,13 @@ To enable this, you must first purchase Lightstep and create a project correspon
 Sourcegraph supports specifying a custom Redis server for:
 
 - caching information (specified via the `REDIS_CACHE_ENDPOINT` environment variable)
-- storing information (session data) (specified via the `REDIS_STORE_ENDPOINT` environment variable)
+- storing information (session data and job queues) (specified via the `REDIS_STORE_ENDPOINT` environment variable)
 
 If you want to specify a custom Redis server, you'll need specify the corresponding environment variable for each of the following deployments:
 
 - `sourcegraph-frontend`
 - `repo-updater`
+- `lsif-server`
 
 ## Configure custom PostgreSQL
 


### PR DESCRIPTION
This will be necessary after https://github.com/sourcegraph/sourcegraph/pull/5525.