### PR TITLE
Update syntect-server to HA implementation (runs 4 workers internally)

### DIFF
--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntect_server:5e1efbb@sha256:6ec136246b302a6c8fc113f087a66d5f9a89a9f5b851e9abb917c8b5e1d8c4b1
+        image: index.docker.io/sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -44,7 +44,7 @@ spec:
         resources:
           limits:
             cpu: "4"
-            memory: 4G
+            memory: 6G
           requests:
             cpu: 250m
             memory: 2G

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntect_server:96e3f14@sha256:f2b5eb5ef162f349e98d2d772955724b8f2b0bf2925797a049d3752953474a88
+        image: index.docker.io/sourcegraph/syntect_server:57ad2ac@sha256:29649661f98e89904b9e383b0b5f9eb3cd88899f18e32267c2bb85c789130117
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
- This PR updates syntect-server to the new HA implementation which internally runs 4 workers.
- Each worker can at peak use ~1.1 GiB, so a 6G memory limit is now suggested.
- The number of workers can be tuned using the env var `WORKERS`. Setting it to `1` would retain the old resource requirements but still be more stable. In practice, tuning it should not be needed.
- A Prometheus metric is also exposed by the container on `:6060/metrics` called `syntect_server_hss_worker_restarts` to measure worker restarts (any restarts indicate a bug in syntect_server).
- For more details, see the first commit message in https://github.com/sourcegraph/syntect_server/pull/25

Closes sourcegraph/sourcegraph#5406