### PR TITLE
lsif-server: add init container to correct file permissions

### DIFF
--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -63,6 +63,17 @@ spec:
           name: lsif-storage
       securityContext:
         runAsUser: 0
+      # lsif-server incorrectly previously ran as `root` instead of the
+      # `sourcegraph` user. We use this init container (ran as root) to fix
+      # the file permissions automatically.
+      initContainers:
+      - name: correct-file-permissions
+        image: alpine:3.10@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
+        command:
+        - chown
+        - -R
+        - 100:101
+        - /lsif-storage
       volumes:
       - name: lsif-storage
         persistentVolumeClaim:


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/sourcegraph/pull/5852 but reviewable independently.