### PR TITLE
upgrade grafana

### DIFF
--- a/base/grafana/grafana.Deployment.yaml
+++ b/base/grafana/grafana.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:10.0.1@sha256:16901ec40e89ed98200c92180655009acd9af002f24189ab6da53eeb48f8f20a
+      - image: index.docker.io/sourcegraph/grafana:10.0.1@sha256:a0c9b339d4bedf86e09f2ee2b612976c997ae867aba5607f9adbf1a0d38544a4
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/grafana/grafana.Deployment.yaml
+++ b/base/grafana/grafana.Deployment.yaml
@@ -24,11 +24,11 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:10.0.0@sha256:f84e4260dce4e36f5d5e9c6deb393ac1e9c930ffae622c432fa86640a1f2699f
+      - image: index.docker.io/sourcegraph/grafana:10.0.1@sha256:16901ec40e89ed98200c92180655009acd9af002f24189ab6da53eeb48f8f20a
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:
-        - containerPort: 3000
+        - containerPort: 3370
           name: http
         volumeMounts:
         - mountPath: /var/lib/grafana


### PR DESCRIPTION
- moves default port to 3370
- upgrades underlying grafana to 6.4.1
- fixes jsonnet dashboard generation for single server
- allows grafana to work outside the reverse proxy

related to https://github.com/sourcegraph/sourcegraph/pull/5910