### PR TITLE
Automerge updating docker image tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,10 +14,7 @@
       "versionScheme": "semver",
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "reviewers": [
-        "ggilmore"
-      ],
-      "extends": ["default:automergeDigest"]
+      "automerge": true,
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Is there any reason for changes like this to not get merged automatically? https://github.com/sourcegraph/deploy-sourcegraph/pull/406