### PR TITLE
prometheus: bump docker image to 10.0.3

### DIFF
--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:10.0.2@sha256:3da967cf3363c7da0e37b8c4928aba66123625303c05645b821f0fead3754e04
+      - image: index.docker.io/sourcegraph/prometheus:10.0.3@sha256:7cbd1b00fc79b7575165d36365304ae70072e91410a1ef70d1e9ccc73e33783e
         env:
         - name: USE_KUBERNETES_DISCOVERY
           value: "true"


### PR DESCRIPTION
10.0.2 discovered too many candidates for alertmanager endpoint