### PR TITLE
all: Migrate svc/indexed-search to a headless service

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -37,6 +37,12 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
+        # ZOEKT_HOST default is indexed-search:80, but for 3.10 the
+        # indexed-search svc has changed to a headless service. So for
+        # installations that still rely on ZOEKT_HOST we need to set it to the
+        # first pod. See 3.10 in migrate.md
+        - name: ZOEKT_HOST
+          value: indexed-search-0.indexed-search:6070
         - name: SRC_GIT_SERVERS
           value: gitserver-0.gitserver:3178
         # POD_NAME is used by CACHE_DIR

--- a/base/indexed-search/indexed-search.Service.yaml
+++ b/base/indexed-search/indexed-search.Service.yaml
@@ -2,16 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    description: Headless service that provides a stable network identity for the
+      indexed-search stateful set.
     prometheus.io/scrape: "true"
   labels:
     app: indexed-search
     deploy: sourcegraph
   name: indexed-search
 spec:
+  clusterIP: None
   ports:
-  - name: http
-    port: 80
-    targetPort: http
+  - port: 6070
   selector:
     app: indexed-search
   type: ClusterIP


### PR DESCRIPTION
This was an oversight in 3.9. We require the service to be headless to be able
to get a stable network identify per indexed-search pod.

More context: https://github.com/sourcegraph/sourcegraph/issues/5725#issuecomment-547304388

Part of https://github.com/sourcegraph/sourcegraph/issues/5725