### PR TITLE
prometheus: constrain service scraping to sourcegraph.prometheus

### DIFF
--- a/base/frontend/sourcegraph-frontend.Service.yaml
+++ b/base/frontend/sourcegraph-frontend.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph

--- a/base/github-proxy/github-proxy.Service.yaml
+++ b/base/github-proxy/github-proxy.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: github-proxy
     deploy: sourcegraph

--- a/base/gitserver/gitserver.Service.yaml
+++ b/base/gitserver/gitserver.Service.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Headless service that provides a stable network identity for the
       gitserver stateful set.
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     deploy: sourcegraph
     type: gitserver

--- a/base/indexed-search/indexed-search.Service.yaml
+++ b/base/indexed-search/indexed-search.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     description: Headless service that provides a stable network identity for the
       indexed-search stateful set.
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: indexed-search
     deploy: sourcegraph

--- a/base/lsif-server/lsif-server.Service.yaml
+++ b/base/lsif-server/lsif-server.Service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: lsif-server
     deploy: sourcegraph

--- a/base/management-console/mangement-console.Service.yaml
+++ b/base/management-console/mangement-console.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: management-console
     deploy: sourcegraph

--- a/base/pgsql/pgsql.Service.yaml
+++ b/base/pgsql/pgsql.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "9187"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: pgsql
     deploy: sourcegraph

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -203,7 +203,7 @@ data:
       - role: pod
 
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
         action: keep
         regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -120,7 +120,7 @@ data:
       - role: endpoints
 
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
         action: keep
         regex: true
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,9 +25,6 @@ spec:
     spec:
       containers:
       - image: index.docker.io/sourcegraph/prometheus:10.0.4@sha256:03af446c1c1d49e6ac395c06a29a207e8c7b59e6aa1fcf156c0bff63ad88d829
-        env:
-        - name: USE_KUBERNETES_DISCOVERY
-          value: "true"
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:10.0.3@sha256:7cbd1b00fc79b7575165d36365304ae70072e91410a1ef70d1e9ccc73e33783e
+      - image: index.docker.io/sourcegraph/prometheus:10.0.4@sha256:03af446c1c1d49e6ac395c06a29a207e8c7b59e6aa1fcf156c0bff63ad88d829
         env:
         - name: USE_KUBERNETES_DISCOVERY
           value: "true"

--- a/base/query-runner/query-runner.Service.yaml
+++ b/base/query-runner/query-runner.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: query-runner
     deploy: sourcegraph

--- a/base/redis/redis-cache.Service.yaml
+++ b/base/redis/redis-cache.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "9121"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: redis-cache
     deploy: sourcegraph

--- a/base/redis/redis-store.Service.yaml
+++ b/base/redis/redis-store.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "9121"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: redis-store
     deploy: sourcegraph

--- a/base/replacer/replacer.Service.yaml
+++ b/base/replacer/replacer.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: replacer
     deploy: sourcegraph

--- a/base/repo-updater/repo-updater.Service.yaml
+++ b/base/repo-updater/repo-updater.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: repo-updater
     deploy: sourcegraph

--- a/base/searcher/searcher.Service.yaml
+++ b/base/searcher/searcher.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: searcher
     deploy: sourcegraph

--- a/base/symbols/symbols.Service.yaml
+++ b/base/symbols/symbols.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: symbols
     deploy: sourcegraph

--- a/configure/ingress-nginx/mandatory.yaml
+++ b/configure/ingress-nginx/mandatory.yaml
@@ -206,7 +206,7 @@ spec:
         app.kubernetes.io/part-of: ingress-nginx
       annotations:
         prometheus.io/port: "10254"
-        prometheus.io/scrape: "true"
+        sourcegraph.prometheus/scrape: "true"
     spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:

--- a/configure/lang/go/lang-go.Service.yaml
+++ b/configure/lang/go/lang-go.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: lang-go
     deploy: lang-go

--- a/configure/lang/typescript/lang-typescript.Service.yaml
+++ b/configure/lang/typescript/lang-typescript.Service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/port: "6060"
-    prometheus.io/scrape: "true"
+    sourcegraph.prometheus/scrape: "true"
   labels:
     app: lang-typescript
     deploy: lang-typescript


### PR DESCRIPTION
This changes the scraping annotation for services to sourcegraph.prometheus/scrape.

This makes it less likely that customers with additional prometheus instances running in their cluster will have the same label and it prevents our builtin prometheus from scraping services not related to Sourcegraph. The previous annotation is probably what everybody uses because it's copy/pasted from the prometheus kubernetes docs.

Note: this doesn't address the other scraping roles: nodes, endpoints and pods.

We still want those for our dot-com deployment but I'm not sure how useful they are in a customer deployment context. We can restrict those too (in the same way) or delete them.