### PR TITLE
frontend: Do not specify ZOEKT_HOST

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -37,12 +37,6 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
-        # ZOEKT_HOST default is indexed-search:80, but for 3.10 the
-        # indexed-search svc has changed to a headless service. So for
-        # installations that still rely on ZOEKT_HOST we need to set it to the
-        # first pod. See 3.10 in migrate.md
-        - name: ZOEKT_HOST
-          value: indexed-search-0.indexed-search:6070
         - name: SRC_GIT_SERVERS
           value: gitserver-0.gitserver:3178
         # POD_NAME is used by CACHE_DIR


### PR DESCRIPTION
The 3.10 docker images of Sourcegraph use service discovery, so do not require
ZOEKT_HOST to be specified. Additionally, the default has been updated to what
the value was specified as. This means we do not need to include this value.

Adding ZOEKT_HOST was added by
https://github.com/sourcegraph/deploy-sourcegraph/pull/428 but was made
obsolete by https://github.com/sourcegraph/sourcegraph/pull/6296. It being
specified just means we do not use service discovery, and does not lead to any
oter problems.