### PR TITLE
prometheus: pick up rules from container

### DIFF
--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -16,6 +16,7 @@ data:
 
     rule_files:
       - '*_rules.yml'
+      - "/sg_config_prometheus/*_rules.yml"
       - "/sg_prometheus_add_ons/*_rules.yml"
 
     # A scrape configuration for running Prometheus on a Kubernetes cluster.


### PR DESCRIPTION
These were lost when config file moved to ConfigMap.