### PR TITLE
gitserver: app label for service

### DIFF
--- a/base/gitserver/gitserver.Service.yaml
+++ b/base/gitserver/gitserver.Service.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     deploy: sourcegraph
     type: gitserver
+    app: gitserver
   name: gitserver
 spec:
   clusterIP: None
@@ -18,4 +19,5 @@ spec:
     targetPort: 10811
   selector:
     type: gitserver
+    app: gitserver
   type: ClusterIP


### PR DESCRIPTION
prometheus needs the app label.

i added it to the selector too. in the next iteration we can remove the type labels from the statefulset and service if we want to make it more uniform.