### PR TITLE
Distinct container names for redis-store and redis-cache

### DIFF
--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           initialDelaySeconds: 30
           tcpSocket:
             port: redis
-        name: redis
+        name: redis-cache
         ports:
         - containerPort: 6379
           name: redis

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           initialDelaySeconds: 30
           tcpSocket:
             port: redis                       
-        name: redis
+        name: redis-store
         ports:
         - containerPort: 6379
           name: redis


### PR DESCRIPTION
This makes it possible to measure resource consumption separately (which is measured at the container level).

For all the other deployments that I spot checked, the container name matches the deployment name.