### PR TITLE
Update Sourcegraph Docker image tags to v3.12.1

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -50,7 +50,7 @@ spec:
           value: /mnt/cache/$(POD_NAME)
         - name: GRAFANA_SERVER_URL
           value: http://grafana:30070
-        image: index.docker.io/sourcegraph/frontend:3.12.0@sha256:df8e7f702044181c622f01cec5ec3e2ec070c596ccf41cc93d6b921e98636fc8
+        image: index.docker.io/sourcegraph/frontend:3.12.1@sha256:55b2e66ed8303cdaedd9998e6e8dfd93eb9b69c92e00cecad810c6eede2271fb
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.12.0@sha256:7823276bfab9cf8c0e95bfed00af5e94eefebcb6c117f7e62ffa30ebbc17ca50
+        image: index.docker.io/sourcegraph/github-proxy:3.12.1@sha256:f3692d0d229f1504610d7d849251dfe0396ea94edb7325389c9ff7bf3cbecc52
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.12.0@sha256:8df638649262d0792969ac9706a8c54f07dfa5c664235e90622fef12aa3d36f7
+        image: index.docker.io/sourcegraph/gitserver:3.12.1@sha256:693b975d131baf57941a3b551cf9fb7241ede7853d290fddb30e26212c62b0e3
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5

--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/lsif-server:3.12.0@sha256:0ccbccbffe0428230fe10e78b2d5c3f217ecf86d0c653574fbd750201e35342a
+        image: index.docker.io/sourcegraph/lsif-server:3.12.1@sha256:9afda69da68ea606c1aaa9cd18c2d621b5b4088a48133167d1b969f7d13c4014
         terminationMessagePolicy: FallbackToLogsOnError
         name: lsif-server
         livenessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.12.0@sha256:1438bdebf59cf4598a613fc6bdbb0159433080f2adcb56b2dfa9a5c1f0289e28
+        image: index.docker.io/sourcegraph/query-runner:3.12.1@sha256:5df160cdd942db3544a126f8f7fe38760a9d5921b2089c24a3f9e5ff0a177851
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/replacer:3.12.0@sha256:273b799f52fe2a2498b638a21644647bd063ed3e4bb61e4ee0275490236aae74
+        image: index.docker.io/sourcegraph/replacer:3.12.1@sha256:a0de687dc8f7590bcfa0f791e452371fb4d8c542749194bde2aa0830f640b3a2
         terminationMessagePolicy: FallbackToLogsOnError
         name: replacer
         ports:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.12.0@sha256:8adaf4c66d45a78516b97cdeb0da27fa8662557369d28ee03c1944a4e7f799a6
+      - image: index.docker.io/sourcegraph/repo-updater:3.12.1@sha256:32f50b9af12a1d6554e7e99b5304685f0ad7111613d9865b25a9fd9c1ab3c5ed
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.12.0@sha256:4247b13942db8fd7b25dcc33ed3fddf7e7f6d58d9a2cd9bafb6f5e4116d154f4
+        image: index.docker.io/sourcegraph/searcher:3.12.1@sha256:82b8533f60bfc6df6b7ac86bf5a21ed1611da4ad2dde73c52b7559629c501d47
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.12.0@sha256:be0db78124fb07afe32f8d7fa71287a08378abaacbe6d4d70d39d6928d0b1cb1
+        image: index.docker.io/sourcegraph/symbols:3.12.1@sha256:12944d2e3b304921ae5c69a91f95c4966dcfad2f2a1f6abfc5d561814030be31
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:


### PR DESCRIPTION
Renovate has not produced the proper update [within 5 hours](https://sourcegraph.slack.com/archives/CJX299FGE/p1579758914054800) so I produced this change using a script I wrote.

I will publish the script separately and propose we move away from Renovate for updating our Docker image SHAs in specific (not proposing we stop using it for dependency updates in general, or even for third-party Docker images) -- and this will be beneficial to automating more of the release process as well.