### PR TITLE
nginx-ingress: upgrade to 0.29.0

### DIFF
--- a/configure/ingress-nginx/README.md
+++ b/configure/ingress-nginx/README.md
@@ -4,4 +4,4 @@
 
 ## Installing / Updating
 
-See [ingress controller documentation](../../docs/configure.md#ingress-controller-recommended). The resources in this directory are from the `0.24.1` release of [ingress-nginx](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.24.1).
+See [ingress controller documentation](../../docs/configure.md#ingress-controller-recommended). The resources in this directory are from the `0.29.0` release of [ingress-nginx](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.29.0).

--- a/configure/ingress-nginx/cloud-generic.yaml
+++ b/configure/ingress-nginx/cloud-generic.yaml
@@ -15,9 +15,11 @@ spec:
   ports:
     - name: http
       port: 80
+      protocol: TCP
       targetPort: http
     - name: https
       port: 443
+      protocol: TCP
       targetPort: https
   # loadBalancerIP: xxx.xxx.xxx.xxx
 ---

--- a/configure/ingress-nginx/mandatory.yaml
+++ b/configure/ingress-nginx/mandatory.yaml
@@ -208,7 +208,7 @@ spec:
         app.kubernetes.io/part-of: ingress-nginx
       annotations:
         prometheus.io/port: "10254"
-        prometheus.io/scrape: "true"
+        sourcegraph.prometheus/scrape: "true"
     spec:
       # wait up to five minutes for the drain of connections
       terminationGracePeriodSeconds: 300

--- a/configure/ingress-nginx/mandatory.yaml
+++ b/configure/ingress-nginx/mandatory.yaml
@@ -82,14 +82,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - events
@@ -98,6 +90,16 @@ rules:
       - patch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:
@@ -206,12 +208,16 @@ spec:
         app.kubernetes.io/part-of: ingress-nginx
       annotations:
         prometheus.io/port: "10254"
-        sourcegraph.prometheus/scrape: "true"
+        prometheus.io/scrape: "true"
     spec:
+      # wait up to five minutes for the drain of connections
+      terminationGracePeriodSeconds: 300
       serviceAccountName: nginx-ingress-serviceaccount
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0@sha256:464db4880861bd9d1e74e67a4a9c975a6e74c1e9968776d8d4cc73492a56dfa5
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.29.0
           terminationMessagePolicy: FallbackToLogsOnError
           args:
             - /nginx-ingress-controller
@@ -227,8 +233,8 @@ spec:
                 - ALL
               add:
                 - NET_BIND_SERVICE
-            # www-data -> 33
-            runAsUser: 33
+            # www-data -> 101
+            runAsUser: 101
           env:
             - name: POD_NAME
               valueFrom:
@@ -241,8 +247,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+              protocol: TCP
             - name: https
               containerPort: 443
+              protocol: TCP
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -262,5 +270,25 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
 
 ---
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  limits:
+  - min:
+      memory: 90Mi
+      cpu: 100m
+    type: Container


### PR DESCRIPTION
Previously, our nginx pods were failing with the following error: 

```
Failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User "system:serviceaccount:ingress-nginx:nginx-ingress-serviceaccount" cannot list resource "ingresses" in API group "networking.k8s.io" at the cluster scope
```