### PR TITLE
use kustomize to set a namespace

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ns-sourcegraph
+resources:
+  - searcher/searcher.Service.yaml
+  - searcher/searcher.Deployment.yaml
+  - backend.Service.yaml
+  - frontend/sourcegraph-frontend.Role.yaml
+  - frontend/sourcegraph-frontend-internal.Service.yaml
+  - frontend/sourcegraph-frontend.Deployment.yaml
+  - frontend/sourcegraph-frontend.ServiceAccount.yaml
+  - frontend/sourcegraph-frontend.Service.yaml
+  - frontend/sourcegraph-frontend.RoleBinding.yaml
+  - frontend/sourcegraph-frontend.Ingress.yaml
+  - redis/redis-store.Service.yaml
+  - redis/redis-store.Deployment.yaml
+  - redis/redis-cache.Service.yaml
+  - redis/redis-cache.Deployment.yaml
+  - redis/redis-store.PersistentVolumeClaim.yaml
+  - redis/redis-cache.PersistentVolumeClaim.yaml
+  - indexed-search/indexed-search.StatefulSet.yaml
+  - indexed-search/indexed-search.Service.yaml
+  - grafana/grafana.Deployment.yaml
+  - grafana/grafana.ConfigMap.yaml
+  - grafana/grafana.ClusterRoleBinding.yaml
+  - grafana/grafana.Service.yaml
+  - grafana/grafana.ServiceAccount.yaml
+  - grafana/grafana.ClusterRole.yaml
+  - grafana/grafana.PersistentVolumeClaim.yaml
+  - syntect-server/syntect-server.Service.yaml
+  - syntect-server/syntect-server.Deployment.yaml
+  - symbols/symbols.Service.yaml
+  - symbols/symbols.Deployment.yaml
+  - pgsql/pgsql.PersistentVolumeClaim.yaml
+  - pgsql/pgsql.ConfigMap.yaml
+  - pgsql/pgsql.Service.yaml
+  - pgsql/pgsql.Deployment.yaml
+  - prometheus/prometheus.ServiceAccount.yaml
+  - prometheus/prometheus.ClusterRoleBinding.yaml
+  - prometheus/prometheus.ConfigMap.yaml
+  - prometheus/prometheus.Deployment.yaml
+  - prometheus/prometheus.PersistentVolumeClaim.yaml
+  - prometheus/prometheus.ClusterRole.yaml
+  - prometheus/prometheus.Service.yaml
+  - query-runner/query-runner.Service.yaml
+  - query-runner/query-runner.Deployment.yaml
+  - github-proxy/github-proxy.Service.yaml
+  - github-proxy/github-proxy.Deployment.yaml
+  - replacer/replacer.Service.yaml
+  - replacer/replacer.Deployment.yaml
+  - repo-updater/repo-updater.Service.yaml
+  - repo-updater/repo-updater.Deployment.yaml
+  - gitserver/gitserver.Service.yaml
+  - gitserver/gitserver.StatefulSet.yaml
+  - lsif-server/lsif-server.Service.yaml
+  - lsif-server/lsif-server.PersistentVolumeClaim.yaml
+  - lsif-server/lsif-server.Deployment.yaml


### PR DESCRIPTION
kustomize (https://kustomize.io/) is built into kubectl and seems a pretty standard way to do customizations like a namespace, custom config maps, overlays, etc.

This experiment proves that we can launch a Sourcegraph instance in a namespace like so:

```sh
cd base
# create the necessary storage class and then:
kubectl create namespace ns-sourcegraph
kubectl apply -k .
```

There's way more possibilities here with kustomization. I will try out more stuff in this direction. It is possible this will be a way for us to provide pemission-restricted k8s configs, configs for different runtimes (ie minikube or k3s), different scaling params (replicas etc). And it seems to be a blessed way to do it by the kubernetes team (integrated and documented).

Tested on a gcp cluster.