### PR TITLE
Mention indexed-search scaling in installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,7 @@
 
 1. Configure the `sourcegraph` storage class for the cluster by reading through ["Configure a storage class"](./configure.md#configure-a-storage-class).
 
-1. If you want to add a large number of repositories to your instance, you should [configure the number of gitserver replicas](configure.md#configure-gitserver-replica-count) _before_ you continue with the next step.
+1. If you want to add a large number of repositories to your instance, you should [configure the number of gitserver replicas](configure.md#configure-gitserver-replica-count) and [the number of indexed-search replicas](configure.md#configure-indexed-search-replica-count) _before_ you continue with the next step. (See ["Tuning replica counts for horizontal scalability"](scale.md#tuning-replica-counts-for-horizontal-scalability) for guidelines.)
 
 1. Deploy the desired version of Sourcegraph to your cluster:
 

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -1,11 +1,10 @@
 # Scaling
 
-Sourcegraph Data Center can be configured to scale to very large codebases and large numbers of
+Sourcegraph can be configured to scale to very large codebases and large numbers of
 users. If you notice latency for search or code intelligence is higher than desired, changing these
 parameters can yield a drastic improvement in performance.
 
-> For assistance scaling and tuning
-> Sourcegraph, [contact us](https://about.sourcegraph.com/contact/). We're happy to help!
+> For assistance when scaling and tuning Sourcegraph, [contact us](https://about.sourcegraph.com/contact/). We're happy to help!
 
 ## Tuning replica counts for horizontal scalability
 


### PR DESCRIPTION
It's really hard to find this in our docs, so I added it to the installation instructions along with the gitserver replicas and linked to the `scale.md` doc.

@keegancsmith That `scale.md` doc is also missing some numbers on Zoekt. That might be valuable to have.