### PR TITLE
non-privileged kustomization

### DIFF
--- a/base/frontend/sourcegraph-frontend.Role.yaml
+++ b/base/frontend/sourcegraph-frontend.Role.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: escalated
   name: sourcegraph-frontend
 rules:
 - apiGroups:

--- a/base/prometheus/prometheus.ClusterRole.yaml
+++ b/base/prometheus/prometheus.ClusterRole.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: escalated
   name: prometheus
 rules:
 - apiGroups:

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: escalated
   name: prometheus
 roleRef:
   apiGroup: ""

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -37,6 +37,17 @@ restart the necessary containers.
 New installations do not need this `kustomization` and existing installations can operate from base again after the
 migration.
 
+New installations on clusters with restrictive security policies can now use a kustomization to accomodate those restrictions:
+
+```shell script
+cd overlays/non-privileged
+kubectl -n ns-sourcegraph apply -l deploy=sourcegraph,rbac-admin!=escalated -k .
+```
+
+The only requirement for the installer is `admin` cluster role in a given namespace.
+
+> IMPORTANT NOTE: If you change the namespace please change all three occurences in this directory tree to the new value. 
+
 ## 3.11
 
 In 3.11 we removed the management console. If you make use of `CRITICAL_CONFIG_FILE` or `SITE_CONFIG_FILE`, please refer to the [migration notes for Sourcegraph 3.11+](https://docs.sourcegraph.com/admin/migration/3_11).

--- a/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,12 +4,11 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
-  name: sourcegraph-frontend
+  name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""
-  kind: Role
-  name: sourcegraph-frontend
+  kind: ClusterRole
+  name: view
 subjects:
-- kind: ServiceAccount
-  name: sourcegraph-frontend
+  - kind: ServiceAccount
+    name: sourcegraph-frontend

--- a/overlays/non-privileged/kustomization.yaml
+++ b/overlays/non-privileged/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ns-sourcegraph
+bases:
+  - ../../base
+resources:
+  - frontend/sourcegraph-frontend.RoleBinding.yaml
+  - prometheus/prometheus.RoleBinding.yaml
+patchesStrategicMerge:
+  - prometheus/prometheus.ConfigMap.yaml

--- a/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval:     30s
+      evaluation_interval: 30s
+
+    alerting:
+      alertmanagers:
+        - kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - ns-sourcegraph
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name]
+              regex: alertmanager
+              action: keep
+
+    rule_files:
+      - '*_rules.yml'
+      - "/sg_config_prometheus/*_rules.yml"
+      - "/sg_prometheus_add_ons/*_rules.yml"
+
+    scrape_configs:
+    - job_name: 'kubernetes-service-endpoints'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+           - ns-sourcegraph
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: (.+)(?::\d+);(\d+)
+        replacement: $1:$2
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        # Sourcegraph specific customization. We want a more convenient to type label.
+        # target_label: kubernetes_namespace
+        target_label: ns
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
+      # Sourcegraph specific customization. We want a nicer name for job
+      - source_labels: [app]
+        action: replace
+        target_label: job
+      # Sourcegraph specific customization. We want a nicer name for instance
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: instance
+  node_rules.yml: ""
+kind: ConfigMap
+metadata:
+  labels:
+    deploy: sourcegraph
+  name: prometheus

--- a/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
@@ -4,12 +4,11 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
-  name: sourcegraph-frontend
+  name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""
-  kind: Role
-  name: sourcegraph-frontend
+  kind: ClusterRole
+  name: view
 subjects:
-- kind: ServiceAccount
-  name: sourcegraph-frontend
+  - kind: ServiceAccount
+    name: prometheus


### PR DESCRIPTION
For new installations that have restrictive security policies in place.
 
Tested on gke using https://about.sourcegraph.com/handbook/engineering/distribution/k8s_admin_custom_policy

Note: this has to be in a namespace, cannot be in default (cluster-wide) because ClusterRoleBindings became RoleBindings.

Note: Prometheus kubernetes_sd scraping has been limited to service endpoints and constrained to the specified namespace (again because of the restrictions of the role for the prometheus service account.