### PR TITLE
doc: clarify and separate in migration doc the two changes in 3.14

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -39,7 +39,7 @@ restart the necessary containers.
 New installations do not need this `kustomization` and existing installations can operate from base again after the
 migration.
 
-### New installations with restrictive security policies
+### New installations: accommodate clusters with restrictive security policies
 
 New installations on clusters with restrictive security policies can now use a kustomization to accomodate those restrictions:
 

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -6,7 +6,7 @@ version you are upgrading to should be applied (unless otherwise noted).
 
 ## 3.14 (Unreleased)
 
-### Migrating from container user root to non-root user
+### Existing installations: Migrating the container user from root to non-root
 
 Version 3.14 changes the security context of the installation by switching to a non-root user for all containers.
 This allows running Sourcegraph in clusters with restrictive security policies.
@@ -139,4 +139,3 @@ Sourcegraph 3.0 ships with Postgres 11.1. The upgrade procedure is mostly automa
 ## 2.12
 
 Beginning in version 2.12.0, Sourcegraph's Kubernetes deployment [requires an Enterprise license key](https://about.sourcegraph.com/pricing). Follow the steps in [docs/configure.md](docs/configure.md#add-a-license-key).
-

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -6,6 +6,8 @@ version you are upgrading to should be applied (unless otherwise noted).
 
 ## 3.14 (Unreleased)
 
+### Migrating from container user root to non-root user
+
 Version 3.14 changes the security context of the installation by switching to a non-root user for all containers.
 This allows running Sourcegraph in clusters with restrictive security policies.
 
@@ -36,6 +38,8 @@ restart the necessary containers.
 
 New installations do not need this `kustomization` and existing installations can operate from base again after the
 migration.
+
+### New installations with restrictive security policies
 
 New installations on clusters with restrictive security policies can now use a kustomization to accomodate those restrictions:
 


### PR DESCRIPTION
Makes clear what the two changes are and which one is needed for migrating existing installations.