### PR TITLE
file group ownership matches container user:group

### DIFF
--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -47,13 +47,13 @@ spec:
           name: repos
         securityContext:
           runAsUser: 100
-          runAsGroup: 100
+          runAsGroup: 101
         # See the customization guide (../../../docs/configure.md) for information
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
       securityContext:
-        fsGroup: 100
+        fsGroup: 101
       volumes:
       - name: repos
       # See the customization guide (../../../docs/configure.md) for information

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -67,9 +67,9 @@ spec:
           name: data
         securityContext:
           runAsUser: 100
-          runAsGroup: 100
+          runAsGroup: 101
       securityContext:
-        fsGroup: 100
+        fsGroup: 101
       volumes:
       - name: data
   updateStrategy:

--- a/base/lsif-server/lsif-server.Deployment.yaml
+++ b/base/lsif-server/lsif-server.Deployment.yaml
@@ -65,9 +65,9 @@ spec:
           name: lsif-storage
         securityContext:
           runAsUser: 100
-          runAsGroup: 100
+          runAsGroup: 101
       securityContext:
-        fsGroup: 100
+        fsGroup: 101
       volumes:
       - name: lsif-storage
         persistentVolumeClaim:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -70,8 +70,8 @@ spec:
             cpu: 10m
             memory: 50Mi
         securityContext:
-          runAsUser: 100
-          runAsGroup: 100
+          runAsUser: 999
+          runAsGroup: 999
       securityContext:
         fsGroup: 999
       volumes:

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -67,9 +67,9 @@ spec:
             memory: 100Mi
         securityContext:
           runAsUser: 999
-          runAsGroup: 999
+          runAsGroup: 1000
       securityContext:
-        fsGroup: 999
+        fsGroup: 1000
       volumes:
       - name: redis-data
         persistentVolumeClaim:

--- a/overlays/migrate-to-nonroot/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/migrate-to-nonroot/gitserver/gitserver.StatefulSet.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: transfer-file-ownership
           image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-          command: ["sh", "-c", "if [[ \"$(stat -c '%u' /data/repos)\" -ne 100 ]]; then chown -R 100:100 /data/repos; fi"]
+          command: ["sh", "-c", "if [[ \"$(stat -c '%u' /data/repos)\" -ne 100 ]]; then chown -R 100:101 /data/repos; fi"]
           volumeMounts:
             - mountPath: /data/repos
               name: repos

--- a/overlays/migrate-to-nonroot/indexed-search/indexed-search.StatefulSet.yaml
+++ b/overlays/migrate-to-nonroot/indexed-search/indexed-search.StatefulSet.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: transfer-file-ownership
           image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-          command: ["sh", "-c", "chown -R 100:100 /data"]
+          command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
             - mountPath: /data
               name: data

--- a/overlays/migrate-to-nonroot/lsif-server/lsif-server.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/lsif-server/lsif-server.Deployment.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: transfer-file-ownership
           image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-          command: ["sh", "-c", "chown -R 100:100 /lsif-storage"]
+          command: ["sh", "-c", "chown -R 100:101 /lsif-storage"]
           volumeMounts:
             - mountPath: /lsif-storage
               name: lsif-storage

--- a/overlays/migrate-to-nonroot/redis/redis-cache.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/redis/redis-cache.Deployment.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: transfer-file-ownership
           image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-          command: ["sh", "-c", "chown -R 999:999 /redis-data"]
+          command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data
               name: redis-data

--- a/overlays/migrate-to-nonroot/redis/redis-store.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/redis/redis-store.Deployment.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - name: transfer-file-ownership
           image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
-          command: ["sh", "-c", "chown -R 999:999 /redis-data"]
+          command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data
               name: redis-data


### PR DESCRIPTION
in PR https://github.com/sourcegraph/deploy-sourcegraph/pull/534 i made a mistake of just checking

```
id -u <container-user>
```

and assuming group would be the same id. this is just a convention not necessarily true, so this time i checked

```
id -g <container-user>
```
too and made the required changes.

I will test everything one more time (migration and new from scratch and rollback)

NOTE: this all worked before and was tested. the theory is that the fsGroup value makes it work. But having them match exactly is more desirable.