### PR TITLE
docs: migrate explains harmless error message with kubectl-apply-all.sh

### DIFF
--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -19,8 +19,7 @@ It is a harmless error message from `kubectl` which can be safely ignored (`kube
 Instead of running `./kubectl-apply-all.sh` please run
 
 ```text
-cd base
-kubectl apply -k .
+kubectl apply -k base
 ```
  
 ### Existing installations: Migrating the container user from root to non-root

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -6,6 +6,23 @@ version you are upgrading to should be applied (unless otherwise noted).
 
 ## 3.14
 
+### Harmless error message
+
+When running `./kubectl-apply-all.sh` you will see this error message:
+
+```text
+error: unable to recognize "base/kustomization.yaml": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
+```
+
+It is a harmless error message from `kubectl` which can be safely ignored (`kubectl` when using `-f` flag does not accept kustomizations).
+
+Instead of running `./kubectl-apply-all.sh` please run
+
+```text
+cd base
+kubectl apply -k .
+```
+ 
 ### Existing installations: Migrating the container user from root to non-root
 
 Version 3.14 changes the security context of the installation by switching to a non-root user for all containers.


### PR DESCRIPTION
apply -f to a whole directory complains when finding a kustomization.yaml file.

i screwed this up, sorry. it's a harmless message which unfortunately is displayed as an error.

we could make them switch to apply -k by changing kubectl-apply-all.sh to use that instead. the downside is that we then require kubectl client version >= 1.14, which is probably acceptable since it's more than a year old.

