### PR TITLE
Fix nonroot gitserver ssh key

### DIFF
--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -50,7 +50,7 @@ spec:
           runAsGroup: 101
         # See the customization guide (../../../docs/configure.md) for information
         # about configuring gitserver to use an SSH key
-        # - mountPath: /root/.ssh
+        # - mountPath: /home/sourcegraph/.ssh
         #   name: ssh
       securityContext:
         fsGroup: 101

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -215,7 +215,7 @@ If you exposed your Sourcegraph instance via the altenative nginx service as des
 
 ## Configure repository cloning via SSH
 
-Sourcegraph will clone repositories using SSH credentials if they are mounted at `/root/.ssh` in the `gitserver` deployment.
+Sourcegraph will clone repositories using SSH credentials if they are mounted at `/home/sourcegraph/.ssh` in the `gitserver` deployment.
 
 1. [Create a secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) that contains the base64 encoded contents of your SSH private key (_make sure it doesn't require a password_) and known_hosts file.
 
@@ -242,7 +242,7 @@ Sourcegraph will clone repositories using SSH credentials if they are mounted at
    spec:
      containers:
        volumeMounts:
-         - mountPath: /root/.ssh
+         - mountPath: /home/sourcegraph/.ssh
            name: ssh
      volumes:
        - name: ssh
@@ -256,7 +256,7 @@ Sourcegraph will clone repositories using SSH credentials if they are mounted at
    ```bash
    # This script requires https://github.com/sourcegraph/jy and https://github.com/sourcegraph/yj
    GS=base/gitserver/gitserver.StatefulSet.yaml
-   cat $GS | yj | jq '.spec.template.spec.containers[].volumeMounts += [{mountPath: "/root/.ssh", name: "ssh"}]' | jy -o $GS
+   cat $GS | yj | jq '.spec.template.spec.containers[].volumeMounts += [{mountPath: "/home/sourcegraph/.ssh", name: "ssh"}]' | jy -o $GS
    cat $GS | yj | jq '.spec.template.spec.volumes += [{name: "ssh", secret: {defaultMode: 384, secretName:"gitserver-ssh"}}]' | jy -o $GS
    ```
 


### PR DESCRIPTION
In the migration from root to non-root users in containers, this bit got missed.  Since `gitserver` no longer runs as root, the SSH key for repo syncs needs to be mounted for the proper user, not for root.

Missing this results in Sourcegraph silently failing to sync repos.  The only indicator of what's wrong is if you check the `gitserver-0` logs.  You'll see a ton of errors like this:

```
t=2020-03-27T23:14:16+0000 lvl=warn msg="error cloning repo" repo=github.com/improbable/inspector err="error cloning repo: repo github.com/improbable/inspector not cloneable: exit status 128 (output follows)\n\nHost key verification failed.\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n"
```

Once the key is emplaced in the right spot, everything works again. 👍 