### PR TITLE
non-root user migration: add /mnt/cache volumes from base

### DIFF
--- a/overlays/migrate-to-nonroot/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/frontend/sourcegraph-frontend.Deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sourcegraph-frontend
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: transfer-cache
+          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
+          volumeMounts:
+          - mountPath: /mnt/cache
+            name: cache-ssd
+          securityContext:
+            runAsUser: 0

--- a/overlays/migrate-to-nonroot/kustomization.yaml
+++ b/overlays/migrate-to-nonroot/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
   - ../../base
 patchesStrategicMerge:
+  - frontend/sourcegraph-frontend.Deployment.yaml
   - gitserver/gitserver.StatefulSet.yaml
   - grafana/grafana.Deployment.yaml
   - indexed-search/indexed-search.StatefulSet.yaml
@@ -11,3 +12,4 @@ patchesStrategicMerge:
   - prometheus/prometheus.Deployment.yaml
   - redis/redis-cache.Deployment.yaml
   - redis/redis-store.Deployment.yaml
+  - searcher/searcher.Deployment.yaml

--- a/overlays/migrate-to-nonroot/searcher/searcher.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/searcher/searcher.Deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searcher
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: transfer-cache
+          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
+          volumeMounts:
+            - mountPath: /mnt/cache
+              name: cache-ssd
+          securityContext:
+            runAsUser: 0


### PR DESCRIPTION
to kustomization

they are emptyDir volumes which could be affected if pod stays on same node during migration to non-root user and then cannot read/write from the cache

this does not address configure/ssd /mnt/cache volumes.

i will change the pod-tmp-gc daemonset there probably