### PR TITLE
CI: restricted test tweaks and escaping of labels

### DIFF
--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -8,9 +8,9 @@ export DEPLOY_SOURCEGRAPH_ROOT=$(pwd)
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
 export TEST_GCP_USERNAME=buildkite@sourcegraph-dev.iam.gserviceaccount.com
-export BUILD_CREATOR=$BUILDKITE_BUILD_CREATOR
+export BUILD_CREATOR=${BUILDKITE_BUILD_CREATOR// /-}
 export BUILD_UUID=$BUILDKITE_BUILD_ID
-export BUILD_BRANCH=$BUILDKITE_BRANCH
+export BUILD_BRANCH=${BUILDKITE_BRANCH//./-}
 
 ${DEPLOY_SOURCEGRAPH_ROOT}/tests/integration/restricted/test.sh
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -48,7 +48,7 @@ kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
 SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe service sourcegraph | grep "LoadBalancer Ingress:" | cut -d ":" -f 2 | tr -d " "`
 
-curl -m 10 http://${SOURCEGRAPH_IP}:3080
+curl -m 60 http://${SOURCEGRAPH_IP}:3080
 
 # delete cluster
 


### PR DESCRIPTION
will switch from NodePort and LoadBalancer to nginx ingress after this one (with the introduction of UDP ports in frontend, loadbalancer cannot be configured anymore)

these small tweaks fix issues discovered this weekend with different branches and build creators