### PR TITLE
build author label escaping

### DIFF
--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -8,9 +8,8 @@ export DEPLOY_SOURCEGRAPH_ROOT=$(pwd)
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
 export TEST_GCP_USERNAME=buildkite@sourcegraph-dev.iam.gserviceaccount.com
-export BUILD_CREATOR=${BUILDKITE_BUILD_CREATOR_EMAIL//[@.]/-}
+export BUILD_CREATOR=`echo ${BUILDKITE_BUILD_CREATOR} | tr '[:upper:]' '[:lower:]' | sed -e 's/[[:blank:]]//g'`
 export BUILD_UUID=$BUILDKITE_BUILD_ID
 export BUILD_BRANCH=${BUILDKITE_BRANCH//./-}
 
 ${DEPLOY_SOURCEGRAPH_ROOT}/tests/integration/restricted/test.sh
-

--- a/tests/integration/restricted/ingress.yaml
+++ b/tests/integration/restricted/ingress.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sourcegraph-ingress
+  namespace: ns-sourcegraph
+spec:
+  backend:
+    serviceName: sourcegraph
+    servicePort: 3080

--- a/tests/integration/restricted/ingress.yaml
+++ b/tests/integration/restricted/ingress.yaml
@@ -1,9 +1,0 @@
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: sourcegraph-ingress
-  namespace: ns-sourcegraph
-spec:
-  backend:
-    serviceName: sourcegraph
-    servicePort: 3080

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -32,7 +32,9 @@ kubectl create rolebinding -n ns-sourcegraph fake-user:nonroot:unprivileged --ro
 
 kubectl --as=system:serviceaccount:ns-sourcegraph:fake-user -n ns-sourcegraph apply -k ${DEPLOY_SOURCEGRAPH_ROOT}/overlays/non-privileged-create-cluster
 
-kubectl  -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort --name sourcegraph --type=LoadBalancer
+kubectl -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort --name sourcegraph
+
+kubectl -n ns-sourcegraph apply -f ingress.yaml
 
 # wait for it all to finish (we list out the ones with persistent volume claim because they take longer)
 
@@ -46,9 +48,9 @@ kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
 # hit it with one request
 
-SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe service sourcegraph | grep "LoadBalancer Ingress:" | cut -d ":" -f 2 | tr -d " "`
+SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress | grep "Address:" | cut -d ":" -f 2 | tr -d " "`
 
-curl -m 60 http://${SOURCEGRAPH_IP}:3080
+curl -m 60 http://${SOURCEGRAPH_IP}
 
 # delete cluster
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -58,7 +58,7 @@ SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress |
 attempt_counter=0
 max_attempts=6
 
-status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP}/site-admin/init)
+status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
 
 while [ ${status_code} -ge 400 ]
 do
@@ -67,7 +67,7 @@ do
       exit 1
     fi
 
-    status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP}/site-admin/init)
+    status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
     attempt_counter=$(($attempt_counter+1))
     sleep 10
 done

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -6,10 +6,10 @@ CLUSTER_NAME_SUFFIX=`echo ${BUILD_UUID} | head -c 8`
 
 CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
 
-function finish {
-  #gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
-}
-trap finish EXIT
+#function finish {
+#  gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
+#}
+#trap finish EXIT
 
 cd $(dirname "${BASH_SOURCE[0]}")
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -58,7 +58,7 @@ SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress |
 attempt_counter=0
 max_attempts=6
 
-until $(curl --output /dev/null --silent --head --fail http://${SOURCEGRAPH_IP}); do
+until $(curl --output /dev/null --silent --fail http://${SOURCEGRAPH_IP}); do
     if [ ${attempt_counter} -eq ${max_attempts} ];then
       echo "Max attempts reached"
       exit 1

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -6,10 +6,10 @@ CLUSTER_NAME_SUFFIX=`echo ${BUILD_UUID} | head -c 8`
 
 CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
 
-#function finish {
-#  gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
-#}
-#trap finish EXIT
+function finish {
+  gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
+}
+trap finish EXIT
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
@@ -53,21 +53,21 @@ kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
 # hit it with one request
 
-SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress | grep "Address:" | cut -d ":" -f 2 | tr -d " "`
-
-attempt_counter=0
-max_attempts=6
-
-status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
-
-while [ ${status_code} -ge 400 ]
-do
-    if [ ${attempt_counter} -eq ${max_attempts} ];then
-      echo "Max attempts reached"
-      exit 1
-    fi
-
-    status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
-    attempt_counter=$(($attempt_counter+1))
-    sleep 10
-done
+#SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress | grep "Address:" | cut -d ":" -f 2 | tr -d " "`
+#
+#attempt_counter=0
+#max_attempts=6
+#
+#status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
+#
+#while [ ${status_code} -ge 400 ]
+#do
+#    if [ ${attempt_counter} -eq ${max_attempts} ];then
+#      echo "Max attempts reached"
+#      exit 1
+#    fi
+#
+#    status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP})
+#    attempt_counter=$(($attempt_counter+1))
+#    sleep 10
+#done

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -58,12 +58,16 @@ SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe ingress sourcegraph-ingress |
 attempt_counter=0
 max_attempts=6
 
-until $(curl --output /dev/null --silent --fail http://${SOURCEGRAPH_IP}); do
+status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP}/site-admin/init)
+
+while [ ${status_code} -ge 400 ]
+do
     if [ ${attempt_counter} -eq ${max_attempts} ];then
       echo "Max attempts reached"
       exit 1
     fi
 
+    status_code=$(curl -o /dev/null -s -w "%{http_code}\n" http://${SOURCEGRAPH_IP}/site-admin/init)
     attempt_counter=$(($attempt_counter+1))
     sleep 10
 done

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -49,7 +49,7 @@ kubectl -n ns-sourcegraph rollout status -w deployment/redis-store
 kubectl -n ns-sourcegraph rollout status -w statefulset/gitserver
 kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
- hit it with one request
+# hit it with one request
 
 SOURCEGRAPH_IP=`kubectl -n ns-sourcegraph describe service sourcegraph | grep "LoadBalancer Ingress:" | cut -d ":" -f 2 | tr -d " "`
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -7,7 +7,7 @@ CLUSTER_NAME_SUFFIX=`echo ${BUILD_UUID} | head -c 8`
 CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
 
 function finish {
-  gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
+  #gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
 }
 trap finish EXIT
 


### PR DESCRIPTION
BUILDKITE_CREATOR_EMAIL is not good because it can have too many characters that are not allowed
(it's debatable if names are worse actually) and also some github emails are redirect emails to protect contributor privacy