### PR TITLE
add timeouts to integration test

### DIFF
--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -55,13 +55,13 @@ kubectl --as=system:serviceaccount:ns-sourcegraph:fake-user -n ns-sourcegraph ap
 
 # wait for it all to finish (we list out the ones with persistent volume claim because they take longer)
 
-kubectl -n ns-sourcegraph rollout status -w statefulset/indexed-search
-kubectl -n ns-sourcegraph rollout status -w deployment/precise-code-intel-bundle-manager
-kubectl -n ns-sourcegraph rollout status -w deployment/prometheus
-kubectl -n ns-sourcegraph rollout status -w deployment/redis-cache
-kubectl -n ns-sourcegraph rollout status -w deployment/redis-store
-kubectl -n ns-sourcegraph rollout status -w statefulset/gitserver
-kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
+timeout 5m kubectl -n ns-sourcegraph rollout status -w statefulset/indexed-search
+timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/precise-code-intel-bundle-manager
+timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/prometheus
+timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/redis-cache
+timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/redis-store
+timeout 5m kubectl -n ns-sourcegraph rollout status -w statefulset/gitserver
+timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
 # hit it with one request
 


### PR DESCRIPTION
Without timeouts, the integration test can hang indefinitely on the following lines:

```
timeout 5m kubectl -n ns-sourcegraph rollout status -w statefulset/indexed-search                                                                              
timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/precise-code-intel-bundle-manager                                                            
timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/prometheus                                                                                   
timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/redis-cache                                                                                  
timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/redis-store                                                                                  
timeout 5m kubectl -n ns-sourcegraph rollout status -w statefulset/gitserver                                                                                   
timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend                                                                                                                                                                                                                                        
```