### PR TITLE
Update image tags to latest master build

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -56,7 +56,7 @@ spec:
           # new value after transition
         - name: PRECISE_CODE_INTEL_API_SERVER_URL
           value: k8s+http://precise-code-intel-api-server:3186
-        image: index.docker.io/sourcegraph/frontend:3.14.2@sha256:44b0221dd9ee60393b3c7273b1214b7ae64cbbb4a8e2b5bcf9d06e521557f0c6
+        image: index.docker.io/sourcegraph/frontend:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.14.2@sha256:0369a42645db81b4211cec54ca685daf365c785e8e213473505df3193ccacccc
+        image: index.docker.io/sourcegraph/github-proxy:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.14.2@sha256:9374262a86f62931856d44912f035467e58b03fcfec82081ba5e486dad5be677
+        image: index.docker.io/sourcegraph/gitserver:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-api-server:59913_2020-04-02_5ae630c@sha256:6cc0050dc4f42519e6554c70ae206a325b503818240b6d7cb57e1b522a37bc90
+        image: index.docker.io/sourcegraph/precise-code-intel-api-server:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-api-server
         livenessProbe:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:59913_2020-04-02_5ae630c@sha256:ef0a1e99721808418b0bf8f37737b9ef63542ca9cc80ffeb673866a400338161
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:59913_2020-04-02_5ae630c@sha256:830b87430a85fb5bee5f18bc85909686dd898bc769890f8d97e8bb90e2b7ac80
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.14.2@sha256:8a22d88a96435755fdcd25aac6b0f395e054c85b863adbfc5f78314b1c0c91a7
+        image: index.docker.io/sourcegraph/query-runner:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/replacer:3.14.2@sha256:b1c68f27a5b0e9ca9924aab9ac77242617d0a523f6c06a4d6de45cca48f0cde1
+        image: index.docker.io/sourcegraph/replacer:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: replacer
         ports:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.14.2@sha256:f7de73c60553f102c8b1d51afc47a3b95bad331c02513cb3d143bfc39b54fff8
+      - image: index.docker.io/sourcegraph/repo-updater:60605_2020-04-09_34ab38e
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.14.2@sha256:a698d805219e715c87cec8fadc37a50ad6c1b7c41e47589b3a162dbe3d45ac97
+        image: index.docker.io/sourcegraph/searcher:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.14.2@sha256:654d15355a34dcfa610fb05f44f2e1c389571b7534d295fa389f63ba958c7df4
+        image: index.docker.io/sourcegraph/symbols:60605_2020-04-09_34ab38e
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:


### PR DESCRIPTION
Master is currently broken as the precise-code-intel tags are newer than the frontend tag and precise-code-intel expects a database version that doesn't exist in the 3.14 branch.

This undoes https://github.com/sourcegraph/deploy-sourcegraph/commit/43c8c05e0db99ed8a9d962463fc2fba58df43090#diff-617545faa1b764ea0cf42a0880bc2cef