### PR TITLE
reduce grafana pvc from 200Gi to 2Gi

### DIFF
--- a/base/grafana/grafana.PersistentVolumeClaim.yaml
+++ b/base/grafana/grafana.PersistentVolumeClaim.yaml
@@ -9,5 +9,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 2Gi
   storageClassName: sourcegraph

--- a/base/grafana/grafana.PersistentVolumeClaim.yaml
+++ b/base/grafana/grafana.PersistentVolumeClaim.yaml
@@ -9,5 +9,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 1Gi
   storageClassName: sourcegraph


### PR DESCRIPTION
Grafana disk usage is only 60mb on k8s.sgdev.org and sourcegraph.com, so why do we ask for 200gb? Fixes https://github.com/sourcegraph/deploy-sourcegraph/issues/387.