### PR TITLE
jaeger-all-in-one: non-root permissions on /tmp

### DIFF
--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: sourcegraph/jaeger-all-in-one:1.17.1@sha256:8ebae08d3c9d70ef0257e2c7a4f6bca35b8f4d490cef563e2ab6ffe543fd47d3
+          - image: sourcegraph/jaeger-all-in-one:1.17.1@sha256:46bfa2ac08dd08181ab443ef966d664048a6c6ac725054bcc1fbfda5bd4040a3
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/dockerfiles/jaeger/all-in-one/Dockerfile
+++ b/dockerfiles/jaeger/all-in-one/Dockerfile
@@ -1,5 +1,7 @@
-# This Dockerfile tracks jaegertracing/all-in-one, but includes more debugging tools and runs as a
-# non-root user. It requires JAEGER_VERSION to be set as an argument to build.
+# This Dockerfile tracks jaegertracing/all-in-one
+# (https://github.com/jaegertracing/jaeger/blob/master/cmd/all-in-one/Dockerfile), but includes more
+# debugging tools and runs as a non-root user. It requires JAEGER_VERSION to be set as an argument
+# to build.
 ARG JAEGER_VERSION
 FROM jaegertracing/all-in-one:$JAEGER_VERSION as base
 
@@ -37,6 +39,12 @@ EXPOSE 14250
 # Web HTTP
 EXPOSE 16686
 
+# Ensure the /tmp directory is chown'd to user jaeger
+USER root
+RUN mkdir -p /tmp
+RUN chown -R jaeger /tmp
+USER jaeger
 VOLUME ["/tmp"]
+
 ENTRYPOINT ["/go/bin/all-in-one-linux"]
 CMD ["--sampling.strategies-file=/etc/jaeger/sampling_strategies.json"]

--- a/dockerfiles/jaeger/all-in-one/Makefile
+++ b/dockerfiles/jaeger/all-in-one/Makefile
@@ -1,0 +1,9 @@
+.PHONY: build upload build-and-upload
+
+build:
+	./build.sh
+
+upload:
+	./upload.sh
+
+build-and-upload: build upload

--- a/dockerfiles/jaeger/all-in-one/build.sh
+++ b/dockerfiles/jaeger/all-in-one/build.sh
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-VERSION="${VERSION:-1.17.1}"
+. version.sh
 
 echo "Building image for Jaeger $VERSION"
 
 docker build --build-arg JAEGER_VERSION="$VERSION" . -t "sourcegraph/jaeger-all-in-one:$VERSION"
-docker push "sourcegraph/jaeger-all-in-one:$VERSION"

--- a/dockerfiles/jaeger/all-in-one/upload.sh
+++ b/dockerfiles/jaeger/all-in-one/upload.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. version.sh
+
+echo "Uploading image for Jaeger $VERSION"
+
+docker push "sourcegraph/jaeger-all-in-one:$VERSION"

--- a/dockerfiles/jaeger/all-in-one/version.sh
+++ b/dockerfiles/jaeger/all-in-one/version.sh
@@ -1,0 +1,1 @@
+VERSION="${VERSION:-1.17.1}"


### PR DESCRIPTION
This addresses https://github.com/sourcegraph/deploy-sourcegraph/pull/559#discussion_r405182789

Post-merge:
- [ ] Move Docker images to https://github.com/sourcegraph/sourcegraph/tree/master/docker-images