### PR TITLE
restricted test: cluster labels have temporarily hardcoded values

### DIFF
--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -7,8 +7,12 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
 export TEST_GCP_USERNAME=buildkite@sourcegraph-dev.iam.gserviceaccount.com
-export BUILD_CREATOR="$(echo "$BUILDKITE_BUILD_CREATOR" | tr ' @./' '_' | tr 'A-Z' 'a-z')"
+# TODO(uwedeportivo): fix to comply with label restrictions (lowercase, less than 60, only _ and maybe others)
+# export BUILD_CREATOR="$(echo "$BUILDKITE_BUILD_CREATOR" | tr ' @./' '_' | tr 'A-Z' 'a-z')"
+export BUILD_CREATOR=unknown
 export BUILD_UUID=$BUILDKITE_BUILD_ID
-export BUILD_BRANCH="$(echo $BUILDKITE_BRANCH | tr ' @./' '_' | tr 'A-Z' 'a-z')"
+# TODO(uwedeportivo): fix to comply with label restrictions (lowercase, less than 60, only _ and maybe others)
+# export BUILD_BRANCH="$(echo $BUILDKITE_BRANCH | tr ' @./' '_' | tr 'A-Z' 'a-z')"
+export BUILD_BRANCH=unknown
 
 ./tests/integration/restricted/test.sh


### PR DESCRIPTION
this is temporarily so i can push releases out.

will fix soon. i have to collect all the restrictions because it keeps biting me