### PR TITLE
new cluster needs rbac roles

### DIFF
--- a/create-new-cluster.sh
+++ b/create-new-cluster.sh
@@ -14,4 +14,5 @@
 # a YAML file that can be `kubectl apply`d to the cluster, version that file in this repository, and add
 # the relevant `kubectl apply` command to ./kubectl-apply-all.sh
 
+kubectl apply -l deploy=sourcegraph -k base/rbac-roles
 kubectl apply -l deploy=sourcegraph -k overlays/non-root-create-cluster


### PR DESCRIPTION
rbac-roles cannot be added to overlays/non-root-create-cluster because that overlay is used as base by the non-privileged-create-cluster where these roles are not allowed (kustomize does not support delete)