### PR TITLE
testing: replace 1.16 with 1.17 in GKE testing list

### DIFF
--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -18,7 +18,7 @@ func TestFreshDeployment(t *testing.T) {
 		t.Skip("skipping fresh cluster integration test in short mode")
 	}
 
-	for _, k8sVersion := range []string{"1.14", "1.15", "1.16"} {
+	for _, k8sVersion := range []string{"1.14", "1.15", "1.17"} {
 		k8sVersion := k8sVersion
 
 		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {


### PR DESCRIPTION
1.16 got pull out of gke rapid release channel