### PR TITLE
non-root: document mount path for ssh config

### DIFF
--- a/overlays/non-root/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/non-root/gitserver/gitserver.StatefulSet.yaml
@@ -12,9 +12,20 @@ spec:
           allowPrivilegeEscalation: false
           runAsUser: 100
           runAsGroup: 101
+      # See the customization guide (../../../docs/configure.md) for information
+      # about configuring gitserver to use an SSH key. Note that the mount path changes
+      # from /root to /home/sourcegraph with this non-root overlay. Don't forget to uncomment
+      # the volumes section below also.
+      # - mountPath: /home/sourcegraph/.ssh
+      #   name: ssh
       - name: jaeger-agent
         securityContext:
           # Required to prevent escalations to root.
           allowPrivilegeEscalation: false
           runAsUser: 100
           runAsGroup: 101
+      # volumes:
+      # - name: ssh
+      #   secret:
+      #     defaultMode: 384
+      #     secretName: gitserver-ssh

--- a/overlays/non-root/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/non-root/gitserver/gitserver.StatefulSet.yaml
@@ -24,6 +24,7 @@ spec:
           allowPrivilegeEscalation: false
           runAsUser: 100
           runAsGroup: 101
+      # Uncomment this section along with the other section (see the docstring above the `mountPath` block above) if you're using a SSH key for git cloning.
       # volumes:
       # - name: ssh
       #   secret:


### PR DESCRIPTION
Documents where to mount ssh config for gitserver in non-root overlay.

See https://github.com/sourcegraph/deploy-sourcegraph/pull/571 also