### PR TITLE
migrating update strategy to recreate

### DIFF
--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -14,10 +14,7 @@ spec:
     matchLabels:
       app: pgsql
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -14,10 +14,7 @@ spec:
     matchLabels:
       app: precise-code-intel-bundle-manager
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -14,10 +14,7 @@ spec:
     matchLabels:
       app: prometheus
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -14,10 +14,7 @@ spec:
     matchLabels:
       app: redis-cache
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -14,10 +14,7 @@ spec:
     matchLabels:
       app: redis-store
   strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -1,8 +1,32 @@
 # Migrations
 
+
 This document records manual migrations that are necessary to apply when upgrading to certain
 Sourcegraph versions. All manual migrations between the version you are upgrading from and the
 version you are upgrading to should be applied (unless otherwise noted).
+
+## 3.16
+
+### Note: The following deployments have had their `strategy` changed from `rolling` to `recreate`:
+  - redis-cache
+  - redis-store
+  - pgsql
+  - precise-code-intel-bundle-manager
+  - prometheus
+  
+This change was made to avoid two pods writing to the same volume and causing corruption. 
+
+To implement these changes run the followng:
+
+```shell script
+kubectl apply -f base/precise-code-intel/bundle-manager.Deployment.yaml
+kubectl apply -f base/redis/redis-cache.Deployment.yaml
+kubectl apply -f base/redis/redis-store.Deployment.yaml
+kubectl apply -f base/prometheus/prometheus.Deployment.yaml
+kubectl apply -f base/pgsql/pgsql.Deployment
+```
+
+For more information see[#676](https://github.com/sourcegraph/deploy-sourcegraph/pull/676)
 
 ## 3.15
 


### PR DESCRIPTION
addresses sourcegraph/sourcegraph#2076 as an example of what can be applied to other services.

Assuming customers have deployed this using `kubectl apply` and not `kubectl create` no other scripting should be required to change this property on the deployment.

