### PR TITLE
overlays: readme fixes and namespaced prometheus rbac

### DIFF
--- a/base/grafana/README.md
+++ b/base/grafana/README.md
@@ -3,8 +3,3 @@
 [Grafana](https://https://grafana.com/) is an open-source analytics dashboard application.
 
 A Grafana instance is part of the default Sourcegraph cluster installation. 
-
-## Namespaces
-
-If you are deploying Sourcegraph to a non-default namespace, you'll have to change the namespace specified in
- [grafana.ClusterRoleBinding.yaml](grafana.ClusterRoleBinding.yaml) to the one that you created.

--- a/overlays/minikube/README.md
+++ b/overlays/minikube/README.md
@@ -12,7 +12,6 @@ After executing the script you can apply the generated manifests from the `gener
 
 ```shell script
 minikube start
-cd overlays/minikube
 kubectl create namespace ns-sourcegraph
 kubectl -n ns-sourcegraph apply --prune -l deploy=sourcegraph -f generated-cluster --recursive
 kubectl -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort --name sourcegraph --port=3080 --target-port=3080

--- a/overlays/namespaced/README.md
+++ b/overlays/namespaced/README.md
@@ -1,5 +1,7 @@
 This is a convenient kustomization that adds the specified namespace to all objects.
 
+If you replace `ns-sourcegraph` with your namespace value, make sure to do it in all the places in this directory tree.
+
 To use it, execute the following command from the root directory of this repository:
 
 ```shell script
@@ -15,5 +17,5 @@ kubectl create namespace ns-sourcegraph
 After executing the script you can apply the generated manifests from the `generated-cluster` directory:
 
 ```shell script
-kubectl apply --prune -l deploy=sourcegraph -f generated-cluster --recursive
+kubectl apply -n ns-sourcegraph --prune -l deploy=sourcegraph -f generated-cluster --recursive
 ```

--- a/overlays/namespaced/kustomization.yaml
+++ b/overlays/namespaced/kustomization.yaml
@@ -4,3 +4,5 @@ namespace: ns-sourcegraph
 bases:
   - ../bases/deployments
   - ../bases/rbac-roles
+patchesStrategicMerge:
+  - prometheus/prometheus.ClusterRoleBinding.yaml

--- a/overlays/namespaced/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/overlays/namespaced/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: ns-sourcegraph

--- a/overlays/non-privileged-create-cluster/README.md
+++ b/overlays/non-privileged-create-cluster/README.md
@@ -14,5 +14,5 @@ After executing the script you can apply the generated manifests from the `gener
 
 ```shell script
 kubectl create namespace ns-sourcegraph
-kubectl apply --prune -l deploy=sourcegraph -f generated-cluster --recursive
+kubectl apply -n ns-sourcegraph --prune -l deploy=sourcegraph -f generated-cluster --recursive
 ```

--- a/overlays/non-privileged/README.md
+++ b/overlays/non-privileged/README.md
@@ -13,5 +13,5 @@ To use it, execute the following command from the root directory of this reposit
 After executing the script you can apply the generated manifests from the `generated-cluster` directory:
 
 ```shell script
-kubectl apply --prune -l deploy=sourcegraph -f generated-cluster --recursive
+kubectl apply -n ns-sourcegraph --prune -l deploy=sourcegraph -f generated-cluster --recursive
 ```


### PR DESCRIPTION
Clean up in README instructions and patched a `namespaced` overlay omission (the namespace value needs to be set in the cluster rolebinding for prometheus)