### PR TITLE
add PR template to keep Kubernetes and Docker Compose in sync

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+
+
+
+
+<!--
+  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
+  without a corresponding change in the other repository, unless it truly is specific to
+  this repository.
+-->
+
+Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
+
+<!-- add link or explanation of why it is not needed here -->


### PR DESCRIPTION
Today, changes are sometimes made to the Kubernetes deployment with changes to deploy-sourcegraph-docker (Docker Compose & "Pure Docker") deployments being updated after the fact.

This PR adds a PR template which enforces we be mindful of keeping the two repositories up to date and in sync, which will allow us to release Docker Compose on the same date (20th of every month) as all of our other deployment methods.

See sister change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/103