### PR TITLE
only run LSIF indexing on this repo, not forks of it

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -3,6 +3,7 @@ on:
   - push
 jobs:
   lsif-go:
+    if: github.repository == 'sourcegraph/deploy-sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     steps:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -3,7 +3,7 @@ on:
   - push
 jobs:
   lsif-go:
-    if: github.repository == 'sourcegraph/deploy'
+    if: github.repository == 'sourcegraph/deploy-sourcegraph'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     steps:

--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -3,7 +3,7 @@ on:
   - push
 jobs:
   lsif-go:
-    if: github.repository == 'sourcegraph/deploy-sourcegraph'
+    if: github.repository == 'sourcegraph/deploy'
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     steps:


### PR DESCRIPTION
The LSIF indexing action added in #666 was getting pulled into forks and causing CI errors. This change causes it to only run on the current repo.