### PR TITLE
apply-all script: allow specifying additional flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ generated/
 .pulumi
 Pulumi.*.yaml
 /pkg/gen/openapi-specs
+generated-cluster/

--- a/base/backend.Service.yaml
+++ b/base/backend.Service.yaml
@@ -6,7 +6,7 @@ metadata:
       the same node if possible.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
     group: backend
   name: backend
 spec:

--- a/base/backend.Service.yaml
+++ b/base/backend.Service.yaml
@@ -6,6 +6,7 @@ metadata:
       the same node if possible.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
     group: backend
   name: backend
 spec:

--- a/base/backend.Service.yaml
+++ b/base/backend.Service.yaml
@@ -6,7 +6,7 @@ metadata:
       the same node if possible.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
     group: backend
   name: backend
 spec:

--- a/base/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/base/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/base/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend-internal.Service.yaml
+++ b/base/frontend/sourcegraph-frontend-internal.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend-internal
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Serves the frontend of Sourcegraph via HTTP(S).
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Serves the frontend of Sourcegraph via HTTP(S).
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Serves the frontend of Sourcegraph via HTTP(S).
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       labels:
         app: sourcegraph-frontend
+        deploy: sourcegraph
     spec:
       containers:
       - args:

--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   # See the customization guide (../../../docs/configure.md) for information

--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend
 spec:
   # See the customization guide (../../../docs/configure.md) for information

--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   # See the customization guide (../../../docs/configure.md) for information

--- a/base/frontend/sourcegraph-frontend.Role.yaml
+++ b/base/frontend/sourcegraph-frontend.Role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: escalated
+    sourcegraph-resource-requires: cluster-admin
   name: sourcegraph-frontend
 rules:
 - apiGroups:

--- a/base/frontend/sourcegraph-frontend.Role.yaml
+++ b/base/frontend/sourcegraph-frontend.Role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
+    sourcegraph-rbac-admin: escalated
   name: sourcegraph-frontend
 rules:
 - apiGroups:

--- a/base/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/base/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: escalated
+    sourcegraph-resource-requires: cluster-admin
   name: sourcegraph-frontend
 roleRef:
   apiGroup: ""

--- a/base/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/base/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
+    sourcegraph-rbac-admin: escalated
   name: sourcegraph-frontend
 roleRef:
   apiGroup: ""

--- a/base/frontend/sourcegraph-frontend.Service.yaml
+++ b/base/frontend/sourcegraph-frontend.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend.Service.yaml
+++ b/base/frontend/sourcegraph-frontend.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend.Service.yaml
+++ b/base/frontend/sourcegraph-frontend.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: sourcegraph-frontend
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend
 spec:
   ports:

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
       labels:
         app: github-proxy
+        deploy: sourcegraph
     spec:
       containers:
       - env:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Rate-limiting proxy for the GitHub API.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Rate-limiting proxy for the GitHub API.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Rate-limiting proxy for the GitHub API.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: github-proxy
 spec:
   minReadySeconds: 10

--- a/base/github-proxy/github-proxy.Service.yaml
+++ b/base/github-proxy/github-proxy.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: github-proxy
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: github-proxy
 spec:
   ports:

--- a/base/github-proxy/github-proxy.Service.yaml
+++ b/base/github-proxy/github-proxy.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: github-proxy
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: github-proxy
 spec:
   ports:

--- a/base/github-proxy/github-proxy.Service.yaml
+++ b/base/github-proxy/github-proxy.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: github-proxy
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: github-proxy
 spec:
   ports:

--- a/base/gitserver/gitserver.Service.yaml
+++ b/base/gitserver/gitserver.Service.yaml
@@ -8,7 +8,7 @@ metadata:
     sourcegraph.prometheus/scrape: "true"
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
     type: gitserver
     app: gitserver
   name: gitserver

--- a/base/gitserver/gitserver.Service.yaml
+++ b/base/gitserver/gitserver.Service.yaml
@@ -8,6 +8,7 @@ metadata:
     sourcegraph.prometheus/scrape: "true"
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
     type: gitserver
     app: gitserver
   name: gitserver

--- a/base/gitserver/gitserver.Service.yaml
+++ b/base/gitserver/gitserver.Service.yaml
@@ -8,7 +8,7 @@ metadata:
     sourcegraph.prometheus/scrape: "true"
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
     type: gitserver
     app: gitserver
   name: gitserver

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Stores clones of repositories to perform Git operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: gitserver
 spec:
   replicas: 1

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -20,6 +20,7 @@ spec:
         app: gitserver
         group: backend
         type: gitserver
+        deploy: sourcegraph
     spec:
       containers:
       - args:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Stores clones of repositories to perform Git operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: gitserver
 spec:
   replicas: 1

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Stores clones of repositories to perform Git operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: gitserver
 spec:
   replicas: 1

--- a/base/grafana/grafana.ConfigMap.yaml
+++ b/base/grafana/grafana.ConfigMap.yaml
@@ -14,5 +14,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: grafana

--- a/base/grafana/grafana.ConfigMap.yaml
+++ b/base/grafana/grafana.ConfigMap.yaml
@@ -14,4 +14,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: grafana

--- a/base/grafana/grafana.ConfigMap.yaml
+++ b/base/grafana/grafana.ConfigMap.yaml
@@ -14,5 +14,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: grafana

--- a/base/grafana/grafana.Service.yaml
+++ b/base/grafana/grafana.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: grafana
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: grafana
 spec:
   ports:

--- a/base/grafana/grafana.Service.yaml
+++ b/base/grafana/grafana.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: grafana
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: grafana
 spec:
   ports:

--- a/base/grafana/grafana.Service.yaml
+++ b/base/grafana/grafana.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: grafana
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: grafana
 spec:
   ports:

--- a/base/grafana/grafana.ServiceAccount.yaml
+++ b/base/grafana/grafana.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: grafana

--- a/base/grafana/grafana.ServiceAccount.yaml
+++ b/base/grafana/grafana.ServiceAccount.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: grafana

--- a/base/grafana/grafana.ServiceAccount.yaml
+++ b/base/grafana/grafana.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: grafana

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Metrics/monitoring dashboards and alerts.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: grafana
 spec:
   replicas: 1

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Metrics/monitoring dashboards and alerts.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: grafana
 spec:
   replicas: 1

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         app: grafana
+        deploy: sourcegraph
     spec:
       containers:
       - image: index.docker.io/sourcegraph/grafana:3.15.0@sha256:94ef3e7673d12e92487ca8966ab74b456f685edfc54fb163e1d49c7eaf064e70

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Metrics/monitoring dashboards and alerts.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: grafana
 spec:
   replicas: 1

--- a/base/indexed-search/indexed-search.Service.yaml
+++ b/base/indexed-search/indexed-search.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: indexed-search
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: indexed-search
 spec:
   clusterIP: None

--- a/base/indexed-search/indexed-search.Service.yaml
+++ b/base/indexed-search/indexed-search.Service.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: indexed-search
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: indexed-search
 spec:
   clusterIP: None

--- a/base/indexed-search/indexed-search.Service.yaml
+++ b/base/indexed-search/indexed-search.Service.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: indexed-search
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: indexed-search
 spec:
   clusterIP: None

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Backend for indexed text search operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: indexed-search
 spec:
   replicas: 1

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for indexed text search operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: indexed-search
 spec:
   replicas: 1

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for indexed text search operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: indexed-search
 spec:
   replicas: 1

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: indexed-search
+        deploy: sourcegraph
     spec:
       containers:
       - env:

--- a/base/jaeger/jaeger-collector.Service.yaml
+++ b/base/jaeger/jaeger-collector.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger-collector
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: collector

--- a/base/jaeger/jaeger-collector.Service.yaml
+++ b/base/jaeger/jaeger-collector.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jaeger-collector
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: collector

--- a/base/jaeger/jaeger-collector.Service.yaml
+++ b/base/jaeger/jaeger-collector.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger-collector
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: collector

--- a/base/jaeger/jaeger-query.Service.yaml
+++ b/base/jaeger/jaeger-query.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jaeger-query
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: query

--- a/base/jaeger/jaeger-query.Service.yaml
+++ b/base/jaeger/jaeger-query.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger-query
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: query

--- a/base/jaeger/jaeger-query.Service.yaml
+++ b/base/jaeger/jaeger-query.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger-query
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: query

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         app: jaeger
+        deploy: sourcegraph
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: all-in-one
       annotations:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jaeger
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jaeger
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
     app: jaeger
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/base/pgsql/pgsql.ConfigMap.yaml
+++ b/base/pgsql/pgsql.ConfigMap.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Configuration for PostgreSQL
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: pgsql-conf
 data:
   postgresql.conf: |

--- a/base/pgsql/pgsql.ConfigMap.yaml
+++ b/base/pgsql/pgsql.ConfigMap.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Configuration for PostgreSQL
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: pgsql-conf
 data:
   postgresql.conf: |

--- a/base/pgsql/pgsql.ConfigMap.yaml
+++ b/base/pgsql/pgsql.ConfigMap.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Configuration for PostgreSQL
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: pgsql-conf
 data:
   postgresql.conf: |

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Postgres database for various data.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: pgsql
         group: backend
     spec:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Postgres database for various data.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Postgres database for various data.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: pgsql
 spec:
   minReadySeconds: 10

--- a/base/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/base/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: pgsql
 spec:
   accessModes:

--- a/base/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/base/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: pgsql
 spec:
   accessModes:

--- a/base/pgsql/pgsql.PersistentVolumeClaim.yaml
+++ b/base/pgsql/pgsql.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: pgsql
 spec:
   accessModes:

--- a/base/pgsql/pgsql.Service.yaml
+++ b/base/pgsql/pgsql.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: pgsql
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: pgsql
 spec:
   ports:

--- a/base/pgsql/pgsql.Service.yaml
+++ b/base/pgsql/pgsql.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: pgsql
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: pgsql
 spec:
   ports:

--- a/base/pgsql/pgsql.Service.yaml
+++ b/base/pgsql/pgsql.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: pgsql
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: pgsql
 spec:
   ports:

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Serves precise code intelligence requests.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-api-server
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Serves precise code intelligence requests.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-api-server
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Serves precise code intelligence requests.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-api-server
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: precise-code-intel-api-server
     spec:
       containers:

--- a/base/precise-code-intel/api-server.Service.yaml
+++ b/base/precise-code-intel/api-server.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-api-server
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-api-server
 spec:
   ports:

--- a/base/precise-code-intel/api-server.Service.yaml
+++ b/base/precise-code-intel/api-server.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-api-server
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-api-server
 spec:
   ports:

--- a/base/precise-code-intel/api-server.Service.yaml
+++ b/base/precise-code-intel/api-server.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-api-server
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-api-server
 spec:
   ports:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Stores and manages precise code intelligence bundles.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-bundle-manager
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: precise-code-intel-bundle-manager
     spec:
       containers:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Stores and manages precise code intelligence bundles.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-bundle-manager
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Stores and manages precise code intelligence bundles.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-bundle-manager
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
+++ b/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: bundle-manager
 spec:
   accessModes:

--- a/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
+++ b/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: bundle-manager
 spec:
   accessModes:

--- a/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
+++ b/base/precise-code-intel/bundle-manager.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: bundle-manager
 spec:
   accessModes:

--- a/base/precise-code-intel/bundle-manager.Service.yaml
+++ b/base/precise-code-intel/bundle-manager.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-bundle-manager
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-bundle-manager
 spec:
   ports:

--- a/base/precise-code-intel/bundle-manager.Service.yaml
+++ b/base/precise-code-intel/bundle-manager.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-bundle-manager
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-bundle-manager
 spec:
   ports:

--- a/base/precise-code-intel/bundle-manager.Service.yaml
+++ b/base/precise-code-intel/bundle-manager.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-bundle-manager
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-bundle-manager
 spec:
   ports:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Handles conversion of uploaded precise code intelligence bundles.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-worker
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Handles conversion of uploaded precise code intelligence bundles.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-worker
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Handles conversion of uploaded precise code intelligence bundles.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-worker
 spec:
   minReadySeconds: 10

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: precise-code-intel-worker
     spec:
       containers:

--- a/base/precise-code-intel/worker.Service.yaml
+++ b/base/precise-code-intel/worker.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-worker
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: precise-code-intel-worker
 spec:
   ports:

--- a/base/precise-code-intel/worker.Service.yaml
+++ b/base/precise-code-intel/worker.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-worker
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: precise-code-intel-worker
 spec:
   ports:

--- a/base/precise-code-intel/worker.Service.yaml
+++ b/base/precise-code-intel/worker.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: precise-code-intel-worker
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: precise-code-intel-worker
 spec:
   ports:

--- a/base/prometheus/prometheus.ClusterRole.yaml
+++ b/base/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
+    sourcegraph-rbac-admin: escalated
   name: prometheus
 rules:
 - apiGroups:

--- a/base/prometheus/prometheus.ClusterRole.yaml
+++ b/base/prometheus/prometheus.ClusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: escalated
+    sourcegraph-resource-requires: cluster-admin
   name: prometheus
 rules:
 - apiGroups:

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: escalated
+    sourcegraph-resource-requires: cluster-admin
   name: prometheus
 roleRef:
   apiGroup: ""

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: escalated
+    sourcegraph-rbac-admin: escalated
   name: prometheus
 roleRef:
   apiGroup: ""

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -344,4 +344,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -344,5 +344,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -344,5 +344,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: prometheus
     spec:
       containers:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Collects metrics and aggregates them into graphs.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Collects metrics and aggregates them into graphs.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Collects metrics and aggregates them into graphs.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus
 spec:
   minReadySeconds: 10

--- a/base/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/base/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus
 spec:
   accessModes:

--- a/base/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/base/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus
 spec:
   accessModes:

--- a/base/prometheus/prometheus.PersistentVolumeClaim.yaml
+++ b/base/prometheus/prometheus.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus
 spec:
   accessModes:

--- a/base/prometheus/prometheus.Service.yaml
+++ b/base/prometheus/prometheus.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: prometheus
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus
 spec:
   ports:

--- a/base/prometheus/prometheus.Service.yaml
+++ b/base/prometheus/prometheus.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: prometheus
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus
 spec:
   ports:

--- a/base/prometheus/prometheus.Service.yaml
+++ b/base/prometheus/prometheus.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: prometheus
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus
 spec:
   ports:

--- a/base/prometheus/prometheus.ServiceAccount.yaml
+++ b/base/prometheus/prometheus.ServiceAccount.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus

--- a/base/prometheus/prometheus.ServiceAccount.yaml
+++ b/base/prometheus/prometheus.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus

--- a/base/prometheus/prometheus.ServiceAccount.yaml
+++ b/base/prometheus/prometheus.ServiceAccount.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Saved search query runner / notification service.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: query-runner
     spec:
       containers:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Saved search query runner / notification service.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Saved search query runner / notification service.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: query-runner
 spec:
   minReadySeconds: 10

--- a/base/query-runner/query-runner.Service.yaml
+++ b/base/query-runner/query-runner.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: query-runner
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: query-runner
 spec:
   ports:

--- a/base/query-runner/query-runner.Service.yaml
+++ b/base/query-runner/query-runner.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: query-runner
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: query-runner
 spec:
   ports:

--- a/base/query-runner/query-runner.Service.yaml
+++ b/base/query-runner/query-runner.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: query-runner
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: query-runner
 spec:
   ports:

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: redis-cache
     spec:
       containers:

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Redis for storing short-lived caches.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Redis for storing short-lived caches.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Redis for storing short-lived caches.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-cache
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-cache
 spec:
   accessModes:

--- a/base/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-cache
 spec:
   accessModes:

--- a/base/redis/redis-cache.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-cache.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-cache
 spec:
   accessModes:

--- a/base/redis/redis-cache.Service.yaml
+++ b/base/redis/redis-cache.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: redis-cache
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-cache
 spec:
   ports:

--- a/base/redis/redis-cache.Service.yaml
+++ b/base/redis/redis-cache.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: redis-cache
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-cache
 spec:
   ports:

--- a/base/redis/redis-cache.Service.yaml
+++ b/base/redis/redis-cache.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: redis-cache
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-cache
 spec:
   ports:

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Redis for storing semi-persistent data like user sessions.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Redis for storing semi-persistent data like user sessions.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Redis for storing semi-persistent data like user sessions.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-store
 spec:
   minReadySeconds: 10

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: redis-store
     spec:
       containers:

--- a/base/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-store.PersistentVolumeClaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-store
 spec:
   accessModes:

--- a/base/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-store.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-store
 spec:
   accessModes:

--- a/base/redis/redis-store.PersistentVolumeClaim.yaml
+++ b/base/redis/redis-store.PersistentVolumeClaim.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-store
 spec:
   accessModes:

--- a/base/redis/redis-store.Service.yaml
+++ b/base/redis/redis-store.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: redis-store
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: redis-store
 spec:
   ports:

--- a/base/redis/redis-store.Service.yaml
+++ b/base/redis/redis-store.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: redis-store
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: redis-store
 spec:
   ports:

--- a/base/redis/redis-store.Service.yaml
+++ b/base/redis/redis-store.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: redis-store
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: redis-store
 spec:
   ports:

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for replace operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: replacer
 spec:
   minReadySeconds: 10

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: replacer
     spec:
       containers:

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Backend for replace operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: replacer
 spec:
   minReadySeconds: 10

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for replace operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: replacer
 spec:
   minReadySeconds: 10

--- a/base/replacer/replacer.Service.yaml
+++ b/base/replacer/replacer.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: replacer
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: replacer
 spec:
   ports:

--- a/base/replacer/replacer.Service.yaml
+++ b/base/replacer/replacer.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: replacer
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: replacer
 spec:
   ports:

--- a/base/replacer/replacer.Service.yaml
+++ b/base/replacer/replacer.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: replacer
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: replacer
 spec:
   ports:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -6,7 +6,7 @@ metadata:
       external code hosts and other similar services.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -6,7 +6,7 @@ metadata:
       external code hosts and other similar services.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: repo-updater
     spec:
       containers:

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -6,6 +6,7 @@ metadata:
       external code hosts and other similar services.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: repo-updater
 spec:
   minReadySeconds: 10

--- a/base/repo-updater/repo-updater.Service.yaml
+++ b/base/repo-updater/repo-updater.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: repo-updater
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: repo-updater
 spec:
   ports:

--- a/base/repo-updater/repo-updater.Service.yaml
+++ b/base/repo-updater/repo-updater.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: repo-updater
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: repo-updater
 spec:
   ports:

--- a/base/repo-updater/repo-updater.Service.yaml
+++ b/base/repo-updater/repo-updater.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: repo-updater
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: repo-updater
 spec:
   ports:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for text search operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: searcher
 spec:
   minReadySeconds: 10

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: searcher
     spec:
       containers:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Backend for text search operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: searcher
 spec:
   minReadySeconds: 10

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for text search operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: searcher
 spec:
   minReadySeconds: 10

--- a/base/searcher/searcher.Service.yaml
+++ b/base/searcher/searcher.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: searcher
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: searcher
 spec:
   ports:

--- a/base/searcher/searcher.Service.yaml
+++ b/base/searcher/searcher.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: searcher
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: searcher
 spec:
   ports:

--- a/base/searcher/searcher.Service.yaml
+++ b/base/searcher/searcher.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: searcher
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: searcher
 spec:
   ports:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Backend for symbols operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: symbols
 spec:
   minReadySeconds: 10

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: symbols
     spec:
       containers:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for symbols operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: symbols
 spec:
   minReadySeconds: 10

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for symbols operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: symbols
 spec:
   minReadySeconds: 10

--- a/base/symbols/symbols.Service.yaml
+++ b/base/symbols/symbols.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: symbols
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: symbols
 spec:
   ports:

--- a/base/symbols/symbols.Service.yaml
+++ b/base/symbols/symbols.Service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: symbols
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: symbols
 spec:
   ports:

--- a/base/symbols/symbols.Service.yaml
+++ b/base/symbols/symbols.Service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: symbols
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: symbols
 spec:
   ports:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for syntax highlighting operations.
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        deploy: sourcegraph
         app: syntect-server
     spec:
       containers:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     description: Backend for syntax highlighting operations.
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: Backend for syntax highlighting operations.
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: syntect-server
 spec:
   minReadySeconds: 10

--- a/base/syntect-server/syntect-server.Service.yaml
+++ b/base/syntect-server/syntect-server.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: syntect-server
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: syntect-server
 spec:
   ports:

--- a/base/syntect-server/syntect-server.Service.yaml
+++ b/base/syntect-server/syntect-server.Service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: syntect-server
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: syntect-server
 spec:
   ports:

--- a/base/syntect-server/syntect-server.Service.yaml
+++ b/base/syntect-server/syntect-server.Service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: syntect-server
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: syntect-server
 spec:
   ports:

--- a/create-new-cluster.sh
+++ b/create-new-cluster.sh
@@ -14,4 +14,4 @@
 # a YAML file that can be `kubectl apply`d to the cluster, version that file in this repository, and add
 # the relevant `kubectl apply` command to ./kubectl-apply-all.sh
 
-./kubectl-apply-all.sh
+./kubectl-apply-all.sh $@

--- a/kubectl-apply-all.sh
+++ b/kubectl-apply-all.sh
@@ -7,4 +7,4 @@
 #   * Whenever the configuration for any resource has been updated
 
 # Apply the base Soucegraph deployment
-kubectl apply --prune -l deploy=sourcegraph -f base --recursive
+kubectl apply --prune -l deploy=sourcegraph -f base --recursive $@

--- a/overlays/namespaced/README.md
+++ b/overlays/namespaced/README.md
@@ -12,6 +12,7 @@ You need to create the namespace if it doesn't exist yet (replace `ns-sourcegrap
 
 ```shell script
 kubectl create namespace ns-sourcegraph
+kubectl label namespace ns-sourcegraph name=ns-sourcegraph
 ```
 
 After executing the script you can apply the generated manifests from the `generated-cluster` directory:

--- a/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
@@ -71,5 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
@@ -71,4 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.ConfigMap.yaml
@@ -71,5 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged-create-cluster/prometheus/prometheus.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/overlays/non-privileged/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: sourcegraph-frontend-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
@@ -71,5 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus

--- a/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
@@ -71,4 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus

--- a/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.ConfigMap.yaml
@@ -71,5 +71,5 @@ kind: ConfigMap
 metadata:
   labels:
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus

--- a/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    rbac-admin: non-escalated
+    sourcegraph-rbac-admin: non-escalated
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
+    rbac-admin: non-escalated
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
+++ b/overlays/non-privileged/prometheus/prometheus.RoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     category: rbac
     deploy: sourcegraph
-    sourcegraph-rbac-admin: non-escalated
+    sourcegraph-resource-requires: no-cluster-admin
   name: prometheus-nonprivileged
 roleRef:
   apiGroup: ""

--- a/tests/integration/restricted/sourcegraph.StorageClass.yaml
+++ b/tests/integration/restricted/sourcegraph.StorageClass.yaml
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: sourcegraph
   labels:
-    deploy: sourcegraph
+    deploy: sourcegraph-storage
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd # This configures SSDs (recommended).

--- a/tests/integration/restricted/sourcegraph.StorageClass.yaml
+++ b/tests/integration/restricted/sourcegraph.StorageClass.yaml
@@ -3,7 +3,8 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: sourcegraph
   labels:
-    deploy: sourcegraph-storage
+    deploy: sourcegraph
+    rbac-admin: non-escalated-storage
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd # This configures SSDs (recommended).

--- a/tests/integration/restricted/sourcegraph.StorageClass.yaml
+++ b/tests/integration/restricted/sourcegraph.StorageClass.yaml
@@ -4,7 +4,6 @@ metadata:
   name: sourcegraph
   labels:
     deploy: sourcegraph
-    rbac-admin: non-escalated-storage
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd # This configures SSDs (recommended).


### PR DESCRIPTION
This PR allows passing additional flags into the kubectl command used by kubectl-apply-all.

Can be used to 

```
./kubectl-apply-all.sh --dry-run
```

```
./kubectl-apply-all.sh --dry-run --validate
```

or 

```
./kubectl-apply-all.sh  -l sourcegraph-resource-requires=no-cluster-admin
./kubectl-apply-all.sh  -l sourcegraph-resource-requires=cluster-admin
```

to separate manifests for cluster-wide and non-cluster-wide admins (addresses issue https://github.com/sourcegraph/sourcegraph/issues/9723, modulo documenting it).

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
Kubernetes-specific change with no docker counterpart.