### PR TITLE
docs: update k8s.eks

### DIFF
--- a/docs/k8s.eks.md
+++ b/docs/k8s.eks.md
@@ -81,8 +81,12 @@ On your dev machine:
 1. Install the `aws` CLI tool: [bundled installer](https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-bundle.html), [other installation methods](https://docs.aws.amazon.com/cli/latest/userguide/installing.html).
 2. Follow [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) to create an access key and `aws configure` the CLI to use it.
 3. Install `kubectl` and `aws-iam-authenticator` by following [these steps](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
-4. [Configure `kubectl` to interact with your cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html).
-   - **Important**: If `kubectl` commands prompt you for username/password, be sure that `kubectl version` reports a client version of v1.10+. Older versions of kubectl do not work with the authentication configuration provided by Amazon EKS.
+4. [Configure `kubectl` to interact with your cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html):
+   ```
+   aws eks update-kubeconfig --name ${cluster_name}
+   ```
+
+**Important**: If `kubectl` commands prompt you for username/password, be sure that `kubectl version` reports a client version of v1.10+. Older versions of kubectl do not work with the authentication configuration provided by Amazon EKS.
 
 At this point, `kubectl get svc` should show something like:
 

--- a/docs/k8s.eks.md
+++ b/docs/k8s.eks.md
@@ -19,7 +19,7 @@ Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/us
 Continuing through the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs), create the EKS Cluster VPC:
 
 1. Open the [**AWS CloudFormation console**](https://console.aws.amazon.com/cloudformation/).
-2. Ensure the region in the top right navigation bar is `us-west-2`, `us-east-1`, or `eu-west-1` (others do not support EKS yet as of September 12, 2018).
+2. Ensure the region in the top right navigation bar is an EKS-supported region (see [this list](https://docs.aws.amazon.com/general/latest/gr/eks.html)). <!-- there does not seem to be a nicer list elsewhere -->
 3. Click **Create stack**.
 4. Select the very last **Specify an Amazon S3 template URL** option. Enter `https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-08-30/amazon-eks-vpc-sample.yaml`
 5. Under **Stack name**, enter `eks-vpc-sourcegraph`.

--- a/docs/k8s.eks.md
+++ b/docs/k8s.eks.md
@@ -16,33 +16,39 @@ Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/us
 
 ## Create the Amazon EKS Cluster VPC
 
-Continuing through the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-prereqs), create the EKS Cluster VPC:
-
 1. Open the [**AWS CloudFormation console**](https://console.aws.amazon.com/cloudformation/).
 2. Ensure the region in the top right navigation bar is an EKS-supported region (see [this list](https://docs.aws.amazon.com/general/latest/gr/eks.html)). <!-- there does not seem to be a nicer list elsewhere -->
-3. Click **Create stack**.
-4. Select the very last **Specify an Amazon S3 template URL** option. Enter `https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-08-30/amazon-eks-vpc-sample.yaml`
+3. Click **Create stack**, and select **"with new resources"**.
+4. When prompted to specify a template, select "Amazon S3 URL" as your **Template Source** and enter:
+   ```
+   https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2020-04-21/amazon-eks-vpc-sample.yaml
+   ```
 5. Under **Stack name**, enter `eks-vpc-sourcegraph`.
-6. Click **Next**, **Next**, **Create**.
+6. Click **Next** through the following pages until you get the option to **Create stack**. Review the configuration and click **Create stack**.
+
+For more details on these steps, refer to [Amazon EKS prerequisites: Create your Amazon EKS cluster VPC](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html#vpc-create).
 
 ## Create the Amazon EKS Cluster
-
-Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-create-cluster) to create the EKS Cluster:
 
 1. Open the [**EKS console**](https://console.aws.amazon.com/eks/home#/clusters).
 2. Click **Create cluster**.
 3. Under **Cluster name**, enter `sourcegraph`.
-4. Under **Role ARN**, select `eksServiceRoleSourcegraph`.
+4. Under **Cluster Service Role**, select `eksServiceRoleSourcegraph`.
 5. Under **VPC**, select `eks-vpc-sourcegraph`.
 6. Under **Security groups**, select the one prefixed `eks-vpc-sourcegraph-ControlPlaneSecurityGroup-`. (Do NOT select `NodeSecurityGroup`.)
 7. Accept all other values as default and click **Create**.
 8. Wait for the cluster to finish **CREATING**. This will take around 10 minutes to complete, so grab some ☕.
 
+For more details on these steps, refer to [Amazon EKS prerequisites: Create your Amazon EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html#eks-create-cluster).
+
 ## Create Kubernetes cluster worker nodes
 
 1. Open the [**AWS CloudFormation console**](https://console.aws.amazon.com/cloudformation/).
 2. Click **Create stack**
-3. Select the very last **Specify an Amazon S3 template URL** option and enter `https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-08-30/amazon-eks-nodegroup.yaml`
+3. Select the very last **Specify an Amazon S3 template URL** option and enter  
+   ```
+   https://amazon-eks.s3.us-west-2.amazonaws.com/cloudformation/2020-04-21/amazon-eks-nodegroup.yaml
+   ```
 4. Under **Stack name**, enter `sourcegraph-worker-nodes`.
 5. Under **ClusterName**, enter the exact cluster name you used (`sourcegraph`).
 6. Under **ClusterControlPlaneSecurityGroup**, scroll down or begin typing and select the option prefixed `eks-vpc-sourcegraph-ControlPlaneSecurityGroup-` (Do NOT select the `NodeSecurityGroup`.)
@@ -61,26 +67,21 @@ Follow the [EKS Getting Started guide](https://docs.aws.amazon.com/eks/latest/us
 
 > **Note:** You can always come back here later and modify these values to scale up/down the number of worker nodes. To do so, just visit the console page again, select **Actions**, **Create Change Set For Current Stack**, enter the same template URL mentioned above, modify the values and hit "next" until reviewing final changes, and finally **Execute**.
 
-9. Under **NodeImageId**, choose based on your region:
+9.  Under **KeyName**, choose a valid key name so that you can SSH into worker nodes if needed in the future.
+10.  Under **VpcId**, select `eks-vpc-sourcegraph-VPC`.
+11.  Under **Subnets**, search for and select *all* `eks-vpc-sourcegraph` subnets.
+12.  Click **Next** through the following pages until you get the option to **Create stack**. Review the configuration and click **Create stack**.
 
-| Region                            | Official image ID     |
-| --------------------------------- | --------------------- |
-| US West (Oregon) (us-west-2)      | ami-08cab282f9979fc7a |
-| US East (N. Virginia) (us-east-1) | ami-0b2ae3c6bda8b5c06 |
-| EU (Ireland) (eu-west-1)          | ami-066110c1a7466949e |
+For more details on these steps, refer to [Worker Nodes: Amazon EKS-optimized Linux AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html).
 
-10. Under **KeyName**, choose a valid key name so that you can SSH into worker nodes if needed in the future.
-11. Under **VpcId**, select `eks-vpc-sourcegraph-VPC`.
-12. Under **Subnets**, search for and select all `eks-vpc-sourcegraph` subnets.
-
-## Install `kubectl` v1.10+ and configure access to the cluster
+## Install `kubectl` and configure access to the cluster
 
 On your dev machine:
 
 1. Install the `aws` CLI tool: [bundled installer](https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-bundle.html), [other installation methods](https://docs.aws.amazon.com/cli/latest/userguide/installing.html).
 2. Follow [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) to create an access key and `aws configure` the CLI to use it.
 3. Install `kubectl` and `aws-iam-authenticator` by following [these steps](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html).
-4. [Configure `kubectl` to interact with your cluster](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#eks-configure-kubectl).
+4. [Configure `kubectl` to interact with your cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html).
    - **Important**: If `kubectl` commands prompt you for username/password, be sure that `kubectl version` reports a client version of v1.10+. Older versions of kubectl do not work with the authentication configuration provided by Amazon EKS.
 
 At this point, `kubectl get svc` should show something like:
@@ -95,13 +96,11 @@ kubernetes   ClusterIP   172.20.0.1   <none>        443/TCP   4m
 
 Now it is time to enable the worker nodes created by CloudFormation to actually join the Kubernetes cluster:
 
-1. Download, edit, and save this configuration map file:
-
-```
-curl -O https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-08-30/aws-auth-cm.yaml
-```
-
-2. Replace `<ARN of instance role (not instance profile)>` in the file (_do not_ modify the file otherwise) with the correct value. To find this value,
+1. Download, edit, and save [this configuration map file](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html):
+   ```
+   curl -O curl -o aws-auth-cm.yaml https://amazon-eks.s3.us-west-2.amazonaws.com/cloudformation/2020-04-21/aws-auth-cm.yaml
+   ```
+2. Replace `rolearn` in the file (_do not_ modify the file otherwise) with the correct value. To find this value:
    - Open the [**AWS CloudFormation console**](https://console.aws.amazon.com/cloudformation/).
    - Locate and select the `sourcegraph-worker-nodes` row.
    - Click the **Output** tab, and copy the **NodeInstanceRole** value.
@@ -116,7 +115,7 @@ Follow [these short steps](https://docs.aws.amazon.com/eks/latest/userguide/stor
 
 ## Deploy the Kubernetes Web UI Dashboard (optional)
 
-See https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html
+See [Tutorial: Deploy the Kubernetes Dashboard](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html).
 
 ## Deploy Sourcegraph! 🎉
 

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -23,11 +23,23 @@ table.
   <tr>
     <th colspan="3">Compute nodes</th>
   </tr>
-  <tr><th>Provider</th><th>Node type</th><th>Boot/ephemeral disk size</th></tr>
-  <tr><td><a href="/docs/k8s.eks.md">Amazon EKS (better than plain EC2)</a> </td><td>m5.4xlarge</td><td>N/A</td></tr>
-  <tr><td><a href="https://kubernetes.io/docs/getting-started-guides/aws/">AWS EC2</a></td><td>m5.4xlarge</td><td>N/A</td></tr>
-  <tr><td><a href="https://cloud.google.com/kubernetes-engine/docs/quickstart">Google Kubernetes Engine (GKE)</a></td><td>n1-standard-16</td><td>100 GB (default)</td></tr>
-  <tr><td><a href="/docs/k8s.azure.md">Azure</a> </td><td>D16 v3</td><td>100 GB (SSD preferred)</td></tr>
-  <tr><td><a href="https://kubernetes.io/docs/setup/pick-right-solution/">Other</a></td><td>16 vCPU, 60 GiB memory per node</td><td>100 GB (SSD preferred)</td></tr>
+  <tr>
+    <th>Provider</th><th>Node type</th><th>Boot/ephemeral disk size</th><th>Reference</th>
+  </tr>
+  <tr>
+    <td><b>Amazon EKS (better than plain EC2)</b></td> <td>m5.4xlarge</td> <td>N/A</td> <td><a href="/docs/k8s.eks.md">Deploy Sourcegraph on EKS</a> </td>
+  </tr>
+  <tr>
+    <td><b>AWS EC2</b></td> <td>m5.4xlarge</td> <td>N/A</td> <td><a href="https://kubernetes.io/docs/setup/production-environment/turnkey/aws">Run Kubernetes on EC2</a></td>
+  </tr>
+  <tr>
+    <td><b>Google Kubernetes Engine (GKE)</b></td> <td>n1-standard-16</td> <td>100 GB (default)</td> <td><a href="https://cloud.google.com/kubernetes-engine/docs/quickstart">GKE Quickstart</a></td>
+  </tr>
+  <tr>
+    <td><b>Azure</b></td> <td>D16 v3</td><td>100 GB (SSD preferred)</td> <td><a href="/docs/k8s.azure.md">Deploy Sourcegraph on Azure</a> </td>
+    </tr>
+  <tr>
+    <td><b>Other</b></td> <td>16 vCPU, 60 GiB memory per node</td> <td>100 GB (SSD preferred)</td> <td><a href="https://kubernetes.io/partners/#kcsp">Kubernetes Service Providers</a></td>
+  </tr>
 </table>
 </div>

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -21,7 +21,7 @@ table.
 <div class="resources">
 <table class="table">
   <tr>
-    <th colspan="3">Compute nodes</th>
+    <th colspan="4">Compute nodes</th>
   </tr>
   <tr>
     <th>Provider</th><th>Node type</th><th>Boot/ephemeral disk size</th><th>Reference</th>


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/9724

https://github.com/sourcegraph/deploy-sourcegraph/blob/docs/aws-eks/docs/k8s.md

Some comments (mostly based on https://github.com/sourcegraph/sourcegraph/issues/9724):
* as pointed out in the ticket it seems that the EKS getting-started guide for nodegroups differs from the nodegroup-specific documentation (https://docs.aws.amazon.com/eks/latest/userguide/worker_node_IAM_role.html), but the docs here follow the getting started guide, so it should be safe to stick with?
* updated the format of the `k8s.md` table to hopefully make it more clear that some of those links point to sourcegraph-specific setup
* fixed a number of outdated links

I ran it through the Sourcegraph install steps too - first time around, I configured `t2.medium`'s and the sourcegraph deploy kept blowing up 😢 using the recommended cluster size settings got it up and running though. Overall, not too painful of an experience, but there are quite a few steps

<img width="300" alt="image" src="https://user-images.githubusercontent.com/23356519/81773549-5e3c2e00-949d-11ea-834f-e31abebef3bd.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/23356519/81773513-3d73d880-949d-11ea-912a-78976b3ad2dd.png">


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: n/a (I think? since this is just a docs change)

<!-- add link or explanation of why it is not needed here -->

*note: doing this because it's the first issue listed in my project planning document 😄*