### PR TITLE
Up default memory limit for precise-code-intel-worker

### DIFF
--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -60,9 +60,9 @@ spec:
         resources:
           limits:
             cpu: "2"
-            memory: 2G
+            memory: 4G
           requests:
             cpu: 500m
-            memory: 500M
+            memory: 2G
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
500M/2G is far too low. A test cluster OOM churned running the precise-code-intel integration tests. Upping the memory a bit stopped the crash loop.