### PR TITLE
add prometheus server URL

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,7 +58,7 @@ spec:
           # new value after transition
         - name: PRECISE_CODE_INTEL_API_SERVER_URL
           value: k8s+http://precise-code-intel-api-server:3186
-        - name: PROMETHEUS_SERVER_URL
+        - name: PROMETHEUS_URL
           value: http://prometheus:30090
         image: index.docker.io/sourcegraph/frontend:3.16.0-rc.4@sha256:97a0a0cd27cff6a5aaffc667e563b09a8dff5b968501dba09e2ce4f0a4ac7cd4
         terminationMessagePolicy: FallbackToLogsOnError

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,6 +58,8 @@ spec:
           # new value after transition
         - name: PRECISE_CODE_INTEL_API_SERVER_URL
           value: k8s+http://precise-code-intel-api-server:3186
+        - name: PROMETHEUS_SERVER_URL
+          value: http://prometheus:30090
         image: index.docker.io/sourcegraph/frontend:3.16.0-rc.4@sha256:97a0a0cd27cff6a5aaffc667e563b09a8dff5b968501dba09e2ce4f0a4ac7cd4
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/pull/10704 - adds `PROMETHEUS_SERVER_URL` to allow the frontend to query metrics.


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/108

<!-- add link or explanation of why it is not needed here -->
