### PR TITLE
update docker image tags to 3.16.0

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -60,7 +60,7 @@ spec:
           value: k8s+http://precise-code-intel-api-server:3186
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:3.16.0-rc.5@sha256:7c256c3c9525450d0441e97ca2c583a82503fc7f779dc0e06d877ba29ad92ae2
+        image: index.docker.io/sourcegraph/frontend:3.16.0@sha256:055560401f9c06f0d56fdad9b9233a99770c573a48bd84d27b16609ac1c9658d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -92,7 +92,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.16.0-rc.5@sha256:5388b6c94b706cb2314dd226f4a7ba8fa27ad522ce3199ebc2b9ac10897004bb
+        image: index.docker.io/sourcegraph/github-proxy:3.16.0@sha256:95bedbc3cd61cdbab1d413cdd44d3de7ae9c99261ab4bd6065520433c515a955
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.16.0-rc.5@sha256:e64c68891d061cde4c9e44578f539e13cd34c47d897737846f088a2d378efc06
+        image: index.docker.io/sourcegraph/gitserver:3.16.0@sha256:31987e80f7137fe635add74f24d60872db8702d4fb07b5e00dcd4877ab9bcb21
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:3.15.0@sha256:94ef3e7673d12e92487ca8966ab74b456f685edfc54fb163e1d49c7eaf064e70
+      - image: index.docker.io/sourcegraph/grafana:3.16.0@sha256:771dd20ea85af7ba188022078f6937f035cab48f312929b8056831b0418b8cfe
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:3.16.0-rc.5@sha256:d8b0fa59f7825acc51ef3cfe9d625019555dceb3272d44b52e396cc7748eaa06
+        image: index.docker.io/sourcegraph/indexed-searcher:3.16.0@sha256:d8b0fa59f7825acc51ef3cfe9d625019555dceb3272d44b52e396cc7748eaa06
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -46,7 +46,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:3.16.0-rc.5@sha256:fa1eaf045fbd2cab1cd2666046718e47d43012efbe07ad68beda0ac778f62875
+        image: index.docker.io/sourcegraph/search-indexer:3.16.0@sha256:fa1eaf045fbd2cab1cd2666046718e47d43012efbe07ad68beda0ac778f62875
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.16.0-rc.5@sha256:ce27bed242f51142abf649ee4f69afeef1b0f30ad5b9cc5af4d6b36c21d1b258
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.16.0@sha256:5dc2e970804028fc945abffc6c961d755df3b1d7b0b6f6516e9f67cb218ed249
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.16.0-rc.5@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+        image: index.docker.io/sourcegraph/postgres-11.4:3.16.0@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/precise-code-intel/api-server.Deployment.yaml
+++ b/base/precise-code-intel/api-server.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-api-server:3.16.0-rc.5@sha256:6eba624a282340618f063e10e09c14066e5e645c877d22757c05f0a5b04447c0
+        image: index.docker.io/sourcegraph/precise-code-intel-api-server:3.16.0@sha256:3a02d6ac32ab319050bbfd9b3a82d1ce00a2c262fcde57dc884f00bdb5a1513a
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-api-server
         livenessProbe:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -32,7 +32,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:3.16.0-rc.5@sha256:e5d9397a39a8d44b1b7b20564e509f5424c92b139c6debca9c6941a03aec159b
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:3.16.0@sha256:e9d8d328f2bc495ead40a7649432d437e306eee6866f895387b88605525f3702
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.16.0-rc.5@sha256:a06e990c29632146602b6d6e7ce20efdcc77084553704c6b661b714799c40acb
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.16.0@sha256:9e81c02d203c0dd80e7b2b4a9d3a5b4c74aa9f4d1c86b2aba84f712ea870313c
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:3.16.0-rc.4@sha256:1091ad7afabc2b5e13a2e6a29d4c29f09982281db0b780af5d6fda93fa18e150
+      - image: index.docker.io/sourcegraph/prometheus:3.16.0@sha256:a1c1dd10d3deec10a20fef030c6fe26a7b72ccc93e9584b7b2db7fbf0ec0d311
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.16.0-rc.5@sha256:8b2dcd94a2be9405594a345f07dfdf63c688fc58ca3f75059f609d1f6728aea9
+        image: index.docker.io/sourcegraph/query-runner:3.16.0@sha256:8db48c533125318a4981ecd1dc8177ba533e2830c79efd50480e301513bb072d
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:3.16.0-rc.5@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.16.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:3.16.0-rc.5@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.16.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/replacer:3.16.0-rc.5@sha256:ccf2696f45725e421ebdba5b648f33eaf259b2bba874b79137239c44a97cffc3
+        image: index.docker.io/sourcegraph/replacer:3.16.0@sha256:837253e0bed4746d9a31e56f27078f88a5567f681c58844916d40841c33a7782
         terminationMessagePolicy: FallbackToLogsOnError
         name: replacer
         ports:
@@ -60,7 +60,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.16.0-rc.5@sha256:bda5caa9e39325b899584a59aabb2a3a488207a2b1d52b36e8d5d88f4c2422ee
+      - image: index.docker.io/sourcegraph/repo-updater:3.16.0@sha256:4ed82310dc1d435041748660a377a59c1dc530317d61bc4b080a0c1ef6ce4cb9
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -43,7 +43,7 @@ spec:
           requests:
             cpu: 100m
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.16.0-rc.5@sha256:9a03332e4d612e3b66f8daa847be49e0f718985a1b3b0d8e89f516209465e3be
+        image: index.docker.io/sourcegraph/searcher:3.16.0@sha256:7dc22bb28e2681d4d0a0f3f3116e62bcde305c6b554db6dce4087fbfc99c5276
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -60,7 +60,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.16.0-rc.5@sha256:e109f41563fc68d2066a54d6f3db72e008d4ede8ee73a25b35be63afb47e969e
+        image: index.docker.io/sourcegraph/symbols:3.16.0@sha256:b5da6814c2a03df210e2258365989a5ba0246ca8b1297d65604bcf9e5e8d6788
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0-rc.5@sha256:f818e8c99f5586f33f770d4ac639dcaa9786e68f3be39bdfeba36a402210754a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.16.0@sha256:ad1fc2f6b69ba3622f872bb105ef07dec5e5a539d30e733b006e88445dbe61e1
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.16.0-rc.5@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.16.0@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
using stephen's update bot (thanks for that !)


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->

sister PR comes later in the release captain checklist