### PR TITLE
Add env var to frontend deployment for Jaeger

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -52,6 +52,8 @@ spec:
           value: /mnt/cache/$(POD_NAME)
         - name: GRAFANA_SERVER_URL
           value: http://grafana:30070
+        - name: JAEGER_SERVER_URL
+          value: http://jaeger-query:16686
         - name: PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/10491

Tested with "index.docker.io/sourcegraph/frontend:insiders@sha256:a5b2eadbab0c0d2fda9bccddcad4e62d6816a9aff6898dedd93e8a65c8e4f26b" &
index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:7b3d2f619ef8d15a62d25ab42688251baeb16dbe3a5924a7cf2a9699adf8d8ab




<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/116

<!-- add link or explanation of why it is not needed here -->