### PR TITLE
docs: point leftover overlay readme to sourcegraph docs instead

### DIFF
--- a/overlays/README.md
+++ b/overlays/README.md
@@ -1,19 +1,3 @@
-# Overlays for kustomizations
-
-This directory contains overlays for various [kustomizations](https://kustomize.io/). kustomize has become a standard way
-to specialize a set of Kubernetes YAML config files for different cluster setups, environments and other parametrizations.
-Starting with client version 1.14 of `kubectl` it is built into kubectl itself and can be used with the `apply` command
-and the flag `-k` instead of flag `-f`.
-
-If your kubectl version is older and doesn't support `apply -k` you can still use these kustomizations. You need to 
-install the standalone [kustomize](https://kustomize.io/) binary, generate the YAML files with `kustomize build` and
-then use the built YAML with `kubectl apply -f`. For example:
-
-```shell script
-cd overlays/namespaced
-kustomize build | kubectl apply -f -
-```
-
-
+Moved to https://docs.sourcegraph.com/admin/install/kubernetes/configure#handling-overlays-in-this-repository
  
 


### PR DESCRIPTION
Missed this readme when i scrubbed the docs and moved them to docs.sourcegraph.com

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

no overlays there (thank goodness :-) )