### PR TITLE
monitoring: add second service to indexed search to expose prom scrape

### DIFF
--- a/base/indexed-search/indexed-search.IndexerService.yaml
+++ b/base/indexed-search/indexed-search.IndexerService.yaml
@@ -5,16 +5,17 @@ metadata:
     description: Headless service that provides a stable network identity for the
       indexed-search stateful set.
     sourcegraph.prometheus/scrape: "true"
-    prometheus.io/port: "6070"
+    prometheus.io/port: "6072"
   labels:
-    app: indexed-search
+    app: indexed-search-indexer
     deploy: sourcegraph
     sourcegraph-resource-requires: no-cluster-admin
-  name: indexed-search
+  name: indexed-search-indexer
 spec:
   clusterIP: None
   ports:
-  - port: 6070
+    - port: 6072
+      targetPort: 6072
   selector:
     app: indexed-search
   type: ClusterIP

--- a/overlays/bases/deployments/kustomization.yaml
+++ b/overlays/bases/deployments/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - base/redis/redis-cache.PersistentVolumeClaim.yaml
   - base/indexed-search/indexed-search.StatefulSet.yaml
   - base/indexed-search/indexed-search.Service.yaml
+  - base/indexed-search/indexed-search.IndexerService.yaml
   - base/jaeger/jaeger.Deployment.yaml
   - base/jaeger/jaeger-collector.Service.yaml
   - base/jaeger/jaeger-query.Service.yaml

--- a/overlays/minikube/grafana-patch.yaml
+++ b/overlays/minikube/grafana-patch.yaml
@@ -1,0 +1,4 @@
+- op: remove
+  path: /spec/volumeClaimTemplates/0/spec/storageClassName
+- op: remove
+  path: /spec/template/spec/containers/0/resources

--- a/overlays/minikube/kustomization.yaml
+++ b/overlays/minikube/kustomization.yaml
@@ -24,11 +24,11 @@ patchesJson6902:
       version: v1
     path: gitserver-patch.yaml
   - target:
-      kind: Deployment
+      kind: StatefulSet
       name: grafana
       group: apps
       version: v1
-    path: delete-resources.yaml
+    path: grafana-patch.yaml
   - target:
       kind: StatefulSet
       name: indexed-search
@@ -115,11 +115,6 @@ patchesJson6902:
   - target:
       kind: PersistentVolumeClaim
       name: bundle-manager
-      version: v1
-    path: delete-storageclassname.yaml
-  - target:
-      kind: PersistentVolumeClaim
-      name: grafana
       version: v1
     path: delete-storageclassname.yaml
   - target:


### PR DESCRIPTION
both zoekt webserver and indexers are now scraped by prometheus

this PR also has small fixes for things found during testing the scraping on minikube and on bigdata test cluster