### PR TITLE
grafana: add jaeger datasource

### DIFF
--- a/base/grafana/grafana.ConfigMap.yaml
+++ b/base/grafana/grafana.ConfigMap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  prometheus.yml: |
+  datasources.yml: |
     apiVersion: 1
 
     datasources:
@@ -10,6 +10,10 @@ data:
         url: http://prometheus:30090
         isDefault: true
         editable: false
+      - name: Jaeger
+        type: Jaeger
+        access: proxy
+        url: http://jaeger-query:16686/-/debug/jaeger
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
depends on https://github.com/sourcegraph/sourcegraph/pull/11583

context: grafana 7 has built-in jaeger support

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/120

<!-- add link or explanation of why it is not needed here -->
