### PR TITLE
update advice for --prune flag

### DIFF
--- a/kubectl-apply-all.sh
+++ b/kubectl-apply-all.sh
@@ -6,8 +6,8 @@
 #   * When the cluster is first created
 #   * Whenever the configuration for any resource has been updated
 #
-# This --prune flag is destructive and should always be used 
-# in conjunction with -f base. Otherwise, it will delete all resources 
+# The --prune flag is destructive and should always be used 
+# in conjunction with -f base and -l deploy=sourcegraph. Otherwise, it will delete all resources 
 # previously created by create or apply that are not specified in the command.
 #
 # Apply the base Soucegraph deployment

--- a/kubectl-apply-all.sh
+++ b/kubectl-apply-all.sh
@@ -5,6 +5,10 @@
 # This file should be run:
 #   * When the cluster is first created
 #   * Whenever the configuration for any resource has been updated
-
+#
+# This --prune flag is destructive and should always be used 
+# in conjunction with -f base. Otherwise, it will delete all resources 
+# previously created by create or apply that are not specified in the command.
+#
 # Apply the base Soucegraph deployment
 kubectl apply --prune -l deploy=sourcegraph -f base --recursive $@


### PR DESCRIPTION
Add note to advise users that --prune is destructive and should always be applied to base directory. Address concern in sourcegraph/sourcegraph#11913 
