### PR TITLE
Update Sourcegraph Docker images Docker tags to v3.17.3 (#780)

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.17.1@sha256:33032e40641ab227e2ec00e7e3655b09542d95f75a6144985908e11f6d0ff332
+        image: index.docker.io/sourcegraph/cadvisor:3.17.3@sha256:e3a10e8257621f24550d6729b45373b27d69c2258a2c8a2c98cb354e3d7d5284
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,7 +58,7 @@ spec:
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:3.17.1@sha256:5b5e8ddd16f7a0af483eb608a842266b35f56ea57fd3b0c342bb642a14cf0647
+        image: index.docker.io/sourcegraph/frontend:3.17.3@sha256:f4bce11424b5c03eccb1318ed3259282da0018e3d51d12924363681d63142035
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -90,7 +90,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.17.1@sha256:bfe02835993a3f3e28475a126cecc4747d565a043534b22788535963bea47dce
+        image: index.docker.io/sourcegraph/github-proxy:3.17.3@sha256:accc0b2c483bda2c1db63d3fd5f7398318e1f0e6e790cd8eb2ad8ee12d5421b8
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.17.1@sha256:b000c12c09e9d447de698702be494e9330459332ae29dd847678f4c889e22d2a
+        image: index.docker.io/sourcegraph/gitserver:3.17.3@sha256:05d596c63d1b1bcba3b229a61ef2d67cc4656cc76104a362f1750278d77ba422
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:3.17.1@sha256:8324943e1b52466dc2052cf82bfd22b18ad045346d2b0ea403b4674f48214602
+        image: index.docker.io/sourcegraph/indexed-searcher:3.17.3@sha256:8324943e1b52466dc2052cf82bfd22b18ad045346d2b0ea403b4674f48214602
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -46,7 +46,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:3.17.1@sha256:f31ec682b907bde2975acda88ee99ac268ef32a79309a6036ef5f26e8af0dcac
+        image: index.docker.io/sourcegraph/search-indexer:3.17.3@sha256:f31ec682b907bde2975acda88ee99ac268ef32a79309a6036ef5f26e8af0dcac
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.17.1@sha256:121577267be0ea87dea327334af4439841f7c3d5801433ade3c7b1a02f840b8f
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.17.3@sha256:bb765283a3e6afaa056f9d0d3ce6cf7231e55e5d62879cab70d3238eca7f446a
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.17.1@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+        image: index.docker.io/sourcegraph/postgres-11.4:3.17.3@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:3.17.1@sha256:f06a81e34f3a215fdd9befc8425ed3a459ba6217cab2d64c0ef70c638d3fdd5f
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:3.17.3@sha256:f3bb86a391a49c22e9eee6e414573307650a884ff38570733b401d88c643bee0
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.17.1@sha256:c859960f3a91362fbf708f5c57166f85250880fd7ad3932859470a381340b8f7
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.17.3@sha256:fb05bdc901d100f5e840765df3669b0f88ffbdab5dc6ad25a18f24d2df258bd7
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.17.1@sha256:1dd628e57b0152c3d8434d4f5e09c82b5b586822dd514c07d4cdda108ba2128f
+        image: index.docker.io/sourcegraph/query-runner:3.17.3@sha256:11ead74fb90367175f5efe059096fc8b89031d90f8e81e76f5d5dc3b7c48d205
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:3.17.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.17.3@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:3.17.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.17.3@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/replacer/replacer.Deployment.yaml
+++ b/base/replacer/replacer.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/replacer:3.17.1@sha256:01ef1cce1d01aca476f9e2d14ddc9cf1ca5c22ac783080124b721898524d5dde
+        image: index.docker.io/sourcegraph/replacer:3.17.3@sha256:a6a3c5ed3046bc22a285395f381b8dc90fea483ea6125c7c394d23a168a2c28c
         terminationMessagePolicy: FallbackToLogsOnError
         name: replacer
         ports:
@@ -60,7 +60,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.17.1@sha256:2fb35dabad52d5f177d52a9036e3f0c45ea63d555ac925addf58f6b13ccd5411
+      - image: index.docker.io/sourcegraph/repo-updater:3.17.3@sha256:c4b58ba7a4d2c7ec1023b9799f65cccc6b430608a00c5bd872705cad5b19c927
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -43,7 +43,7 @@ spec:
           requests:
             cpu: 100m
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.17.1@sha256:82a4dd21553bf31930809a8cd427f11e876f7408e4d06f667f867547dbaa43ea
+        image: index.docker.io/sourcegraph/searcher:3.17.3@sha256:a95dfabfb9231fb0f1b7b34c3174c50ef032d96e8e02b2128802b3d5da3af20a
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -60,7 +60,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.17.1@sha256:3007e47903cf029ccdbbf0b3586fae03190e240a70e90e29f750bea7576930e3
+        image: index.docker.io/sourcegraph/symbols:3.17.3@sha256:eb82df76ce9bd3a1075e74ea8a52fa7bf6b49d7469e94444cba7996203165d96
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.1@sha256:6cc941c5003652e69d9a5cc2e90ce76d2635b92579037fb2e76a94f726d18bad
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.17.1@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.17.3@sha256:aa93514b7bc3aaf7a4e9c92e5ff52ee5052db6fb101255a69f054e5b8cdb46ff
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Co-authored-by: Renovate Bot <bot@renovateapp.com>





<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
