### PR TITLE
repo-updater: bump cpu, memory

### DIFF
--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -38,10 +38,10 @@ spec:
           name: debug
         resources:
           limits:
-            cpu: 100m
-            memory: 500Mi
+            cpu: "4"
+            memory: 4Gi
           requests:
-            cpu: 100m
+            cpu: "1"
             memory: 500Mi
       - image: index.docker.io/sourcegraph/jaeger-agent:3.17.3@sha256:cf9ed3c1dfa1de271d101bea466452e64e3de7407e0878765f45baecfc351bff
         name: jaeger-agent

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -38,8 +38,8 @@ spec:
           name: debug
         resources:
           limits:
-            cpu: "4"
-            memory: 4Gi
+            cpu: "1"
+            memory: 2Gi
           requests:
             cpu: "1"
             memory: 500Mi


### PR DESCRIPTION
corresponds to https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/2975


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: n/a, there are already similar resources configured there https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/deploy-repo-updater.sh

<!-- add link or explanation of why it is not needed here -->
