### PR TITLE
search: generous timeout for search pods

### DIFF
--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -35,6 +35,7 @@ spec:
             port: http
             scheme: HTTP
           periodSeconds: 1
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: "2"

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -50,6 +50,7 @@ spec:
             port: http
             scheme: HTTP
           periodSeconds: 1
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: "2"


### PR DESCRIPTION
These services when searching will use a lot of CPU and IO. This may
make them slow to respond. The readiness probe failing has disasterous
consequences, since k8s' service discovery will remove the pod from the
endpoint list leading to us rebalancing.

This is a guess at a root cause of problems we are seeing on a very
large instance.