### PR TITLE
add app label for prometheus, alertmanager

### DIFF
--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -234,14 +234,18 @@ data:
         action: replace
         target_label: kubernetes_pod_name
 
-    - job_name: 'builtin-alertmanager'
-      metrics_path: /alertmanager/metrics
-      static_configs:
-        - targets: ['127.0.0.1:9093']
     # Scrape prometheus itself for metrics.
     - job_name: 'builtin-prometheus'
       static_configs:
         - targets: ['127.0.0.1:9092']
+          labels:
+            app: prometheus
+    - job_name: 'builtin-alertmanager'
+      metrics_path: /alertmanager/metrics
+      static_configs:
+        - targets: ['127.0.0.1:9093']
+          labels:
+            app: alertmanager
   extra_rules.yml: ""
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/12482

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: n/a

<!-- add link or explanation of why it is not needed here -->
