### PR TITLE
Increase minimum failureThreshold and periodSeconds

### DIFF
--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -29,12 +29,12 @@ spec:
         - containerPort: 6070
           name: http
         readinessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: http
             scheme: HTTP
-          periodSeconds: 1
+          periodSeconds: 5
           timeoutSeconds: 5
         resources:
           limits:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -44,12 +44,12 @@ spec:
         - containerPort: 6060
           name: debug
         readinessProbe:
-          failureThreshold: 1
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: http
             scheme: HTTP
-          periodSeconds: 1
+          periodSeconds: 5
           timeoutSeconds: 5
         resources:
           limits:


### PR DESCRIPTION
Change the failureThreshold and periodSeconds of searcher and
indexed-searcher to be less strict.

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/130