### PR TITLE
prometheus: drop jaeger-agent containers

### DIFF
--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -131,6 +131,9 @@ data:
       - source_labels: [__meta_kubernetes_service_annotation_sourcegraph_prometheus_scrape]
         action: keep
         regex: true
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: drop
+        regex: jaeger-agent
       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
         action: replace
         target_label: __scheme__


### PR DESCRIPTION
mirrors https://github.com/sourcegraph/deploy-sourcegraph-dot-com/commit/f234bcbd56f1b57f34a47c7992be65e933124f9b by @beyang 


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
