### PR TITLE
create update dispatch workflow

### DIFF
--- a/.github/workflows/dispatch-update.yml
+++ b/.github/workflows/dispatch-update.yml
@@ -1,0 +1,39 @@
+name: Dispatch update
+on:
+  push:
+    branches:
+    - master
+  workflow_dispatch:
+    inputs:
+      reason:
+        required: true
+jobs:
+  dispatch:
+    if: github.repository == 'sourcegraph/deploy-sourcegraph'
+    runs-on: ubuntu-latest
+    strategy:
+      # repositories to notify
+      matrix:
+        repository:
+          - sourcegraph/deploy-sourcegraph-dogfood-k8s-2
+    steps:
+      # retrieve first pull request attached to this commit
+      - name: Get pull request
+        id: pull_request
+        run: |
+          NUMBER=$(curl \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.groot-preview+json" \
+            https://api.github.com/repos/sourcegraph/deploy-sourcegraph/commits/${{ github.sha }}/pulls | jq --raw-output '.[0].number' | cat)
+          echo "::set-output name=number::$NUMBER"
+
+      - name: Dispatch to ${{ matrix.repository }}
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          repository: ${{ matrix.repository }}
+          event-type: deploy-sourcegraph-update
+          client-payload: '{"sha":"${{ github.sha }}","actor":"${{ github.actor }}","reason":"${{ github.event.inputs.reason }}","pull_request":"${{ steps.pull_request.outputs.number }}"}'
+          # token must be a personal access token for cross-repo access - currently @sourcegraph-bot cross-repo-github-actions in 1password
+          # token must have `repo` and `admin:repo_hook` scope
+          # configure in https://github.com/sourcegraph/deploy-sourcegraph/settings/secrets/DISPATCH_PERSONAL_ACCESS_TOKEN
+          token: ${{ secrets.DISPATCH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
for https://github.com/sourcegraph/sourcegraph/issues/13121

Adds an action that dispatches a notification that `deploy-sourcegraph` has been updated to https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2 , which then uses the payload to apply the update.

The information dispatched here is pretty minimal and unlikely to change, so I am marking this as ready for review. The https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2 is good to go, just need to add auto-merge

Note: recent tests fail because the new merge strategy won't work with diverged histories


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: n/a

<!-- add link or explanation of why it is not needed here -->
