### PR TITLE
tests: drop k8s 1.14, add 1.16

### DIFF
--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -18,7 +18,7 @@ func TestFreshDeployment(t *testing.T) {
 		t.Skip("skipping fresh cluster integration test in short mode")
 	}
 
-	for _, k8sVersion := range []string{"1.14", "1.15", "1.17"} {
+	for _, k8sVersion := range []string{"1.15", "1.16", "1.17"} {
 		k8sVersion := k8sVersion
 
 		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {


### PR DESCRIPTION
It seems that 1.14 might no longer be available for masters:

```
gcp:container:Cluster ds-integ-fresh-test-cluster **creating failed** error: googleapi: Error 400: Master version "1.14.10-gke.46" is unsupported., badRequest
```

I'm unable to find any documentation supporting this other than an [Aug 6 GKE change indicating that 1.14 masters and nodes are being upgraded to 1.15 automatically](https://cloud.google.com/kubernetes-engine/docs/release-notes#august_06_2020_r26), but @davejrt poked around in the UI and it seems that 1.14 is no longer available in the console.

This change also adds 1.16 to replace 1.14, since it's missing. There is 1.18, but it seems that it is not GA yet

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
