### PR TITLE
jaeger: make cpu limit field text (needed by dhall migrator)

### DIFF
--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
               initialDelaySeconds: 5
             resources:
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: 1G
               requests:
                 cpu: 500m


### PR DESCRIPTION
schema calls for text