### PR TITLE
update renovate to use insiders for sourcegraph docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,18 @@
   "prHourlyLimit": 0,
   "packageRules": [
     {
-      "groupName": "Sourcegraph Docker images",
+      "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "ignoreUnstable": false,
       "followTag": "insiders",
-      "extends": ["default:automergeAll"]
+      "ignoreUnstable": false,
+      "automerge": false
+    },
+    {
+      "groupName": "Sourcegraph Docker release images",
+      "packagePatterns": ["^index.docker.io/sourcegraph/"],
+      "versionScheme": "semver",
+      "ignoreUnstable": false,
+      "automerge": false
     },
     {
       "groupName": "Pulumi NPM packages",

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,13 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["config:base"],
+  "prHourlyLimit": 0,
+  "masterIssue": true,
+  "pinDigests": true,
+  "baseBranches": ["master"],
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
-  "prHourlyLimit": 0,
   "packageRules": [
     {
       "groupName": "Sourcegraph Docker insiders images",
@@ -27,8 +30,5 @@
       "packagePatterns": ["@pulumi/"],
       "followTag": "latest"
     }
-  ],
-  "masterIssue": true,
-  "pinDigests": true,
-  "baseBranches": ["master"]
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,22 +7,11 @@
   "prHourlyLimit": 0,
   "packageRules": [
     {
-      "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "excludePackageNames": ["index.docker.io/sourcegraph/grafana", "index.docker.io/sourcegraph/prometheus"],
       "groupName": "Sourcegraph Docker images",
-      "versionScheme": "semver",
+      "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
-      "semanticCommits": false,
-      "automerge": true
-    },
-    {
-      "packageNames": ["index.docker.io/sourcegraph/grafana", "index.docker.io/sourcegraph/prometheus"],
-      "groupName": "Sourcegraph Prometheus / Grafana Docker images",
-      "allowedVersions": "<10.0",
-      "versionScheme": "semver",
-      "ignoreUnstable": false,
-      "semanticCommits": false,
-      "automerge": true
+      "followTag": "insiders",
+      "extends": ["default:automergeAll"]
     },
     {
       "groupName": "Pulumi NPM packages",
@@ -34,5 +23,5 @@
   ],
   "masterIssue": true,
   "pinDigests": true,
-  "baseBranches": ["master", "3.14"]
+  "baseBranches": ["master"]
 }


### PR DESCRIPTION
This (hopefully) configures renovate to set up a PR with insiders images for this repo as part of https://github.com/sourcegraph/sourcegraph/issues/13122 . Automerge is currently not enabled so that I can verify this.

I'm hoping, along with https://github.com/sourcegraph/sourcegraph/pull/13449, that we can get to a state where commits to Sourcegraph land in this repo and then to downstream repos like https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2 relatively quickly.

**Generating releases**: I'm not entirely sure how we generate releases yet with this new setup - I think we'll have to branch and update images and tag there

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: This change was not planned for `deploy-sourcegraph-docker` as part of https://github.com/sourcegraph/sourcegraph/issues/13122 , but I think it would be possible to adapt it over there if this works out

<!-- add link or explanation of why it is not needed here -->
