### PR TITLE
renovate: align with dot-com settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
+      "semanticCommits": false,
       "automerge": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
     {
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "followTag": "insiders",
       "ignoreUnstable": false,
       "automerge": false
     },


### PR DESCRIPTION
Renovate is erroring on the `followTag` setting, so I'm just getting rid of it - this aligns it with how dot-com is configured https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json#L10-L23

https://app.renovatebot.com/dashboard#github/sourcegraph/deploy-sourcegraph/227259180

follow-up to #845

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
