### PR TITLE
renovate: upgrade to insiders

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
+      "allowedVersions": "/^insiders$/",
       "automerge": false
     },
     {


### PR DESCRIPTION
I'm still unable to get Renovate to run a config locally (the CLI can only look at local config, which renovates remote repositories, so I can't seem to test config changes...)

This change attempts to get Renovate to accept "insiders" tags as "upgrades"


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
