### PR TITLE
rework versioning and release scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Dispatch update
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        required: true
+      branch:
+        required: true
+
+jobs:
+  dispatch:
+    if: github.repository == 'sourcegraph/deploy-sourcegraph'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install update-docker-tags
+        run: go get -u github.com/slimsag/update-docker-tags
+      - name: Pin tags to ${{ github.event.inputs.semver }}
+        run: .github/workflows/scripts/update-docker-tags.sh "${{ github.event.inputs.semver }}"
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ github.event.inputs.branch }}
+          branch: upgrade-${{ github.event.inputs.branch }}
+          labels: release
+          title: 'Upgrade ${{ github.event.inputs.branch }} to ${{ github.event.inputs.semver }}'
+          body: |
+            Upgrade the `${{ github.event.inputs.branch }}` branch's Sourcegraph Docker images to enforce constraints `${{ github.event.inputs.semver }}`.
+
+            This pull request was generate by [this run](https://github.com/sourcegraph/deploy-sourcegraph/actions/runs/${{ github.run_id }})

--- a/.github/workflows/scripts/update-docker-tags.sh
+++ b/.github/workflows/scripts/update-docker-tags.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+CONSTRAINT=$1
+
+update-docker-tags \
+  -enforce="sourcegraph/cadvisor=$CONSTRAINT" \
+  -enforce="sourcegraph/frontend=$CONSTRAINT" \
+  -enforce="sourcegraph/jaeger-agent=$CONSTRAINT" \
+  -enforce="sourcegraph/github-proxy=$CONSTRAINT" \
+  -enforce="sourcegraph/gitserver=$CONSTRAINT" \
+  -enforce="sourcegraph/grafana=$CONSTRAINT" \
+  -enforce="sourcegraph/indexed-searcher=$CONSTRAINT" \
+  -enforce="sourcegraph/search-indexer=$CONSTRAINT" \
+  -enforce="sourcegraph/jaeger-all-in-one=$CONSTRAINT" \
+  -enforce="sourcegraph/postgres-11.4=$CONSTRAINT" \
+  -enforce="sourcegraph/precise-code-intel-bundle-manager=$CONSTRAINT" \
+  -enforce="sourcegraph/precise-code-intel-worker=$CONSTRAINT" \
+  -enforce="sourcegraph/prometheus=$CONSTRAINT" \
+  -enforce="sourcegraph/query-runner=$CONSTRAINT" \
+  -enforce="sourcegraph/redis-cache=$CONSTRAINT" \
+  -enforce="sourcegraph/redis-store=$CONSTRAINT" \
+  -enforce="sourcegraph/repo-updater=$CONSTRAINT" \
+  -enforce="sourcegraph/searcher=$CONSTRAINT" \
+  -enforce="sourcegraph/symbols=$CONSTRAINT" \
+  base/

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,4 +1,4 @@
-name: Dispatch update
+name: Update tags
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   dispatch:
-    if: github.repository == 'sourcegraph/deploy-sourcegraph'
+    if: ${{ github.repository == 'sourcegraph/deploy-sourcegraph' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,18 +1,47 @@
-# Sourcegraph Developer README
+# Deploy-Sourcegraph Developer Guide
 
-## Cutting a release
+- [Docker images](#docker-images)
+  - [Cutting a release](#cutting-a-release)
+  - [Manual image updates](#manual-image-updates)
+- [Testing changes](#testing-changes)
+  - [Open a PR](#open-a-pr)
+  - [Smoke test](#smoke-test)
+    - [Using the sourcegraph/deploy-k8s-helper tool](#using-the-sourcegraphdeploy-k8s-helper-tool)
+      - [Do smoke tests for `master` branch](#do-smoke-tests-for-master-branch)
+      - [Check the upgrade path from the previous release to `master`](#check-the-upgrade-path-from-the-previous-release-to-master)
+    - [Manual instructions](#manual-instructions)
+      - [Provision a new cluster](#provision-a-new-cluster)
+      - [Do smoke tests for `master` branch](#do-smoke-tests-for-master-branch-1)
+      - [Check the upgrade path from the previous release to `master`](#check-the-upgrade-path-from-the-previous-release-to-master-1)
+  - [Minikube](#minikube)
 
-### Make the desired changes to this repository
+## Docker images
 
-#### Updating docker image tags
+Refer to [deployment basics](https://about.sourcegraph.com/handbook/engineering/deployments#deployment-basics) to learn about Sourcegraph Docker images and [Renovate](https://renovatebot.com/docs/docker/), which performs most image updates.
 
-- The vast majority of the time, [Renovate](https://renovatebot.com/docs/docker/) will open PRs in a timely manner.
+The `master` branch of this repository is configured to track the latest builds from `sourcegraph/sourgraph@main`, tagged as `BUILD_YYYY_MM_DD_HASH`. Renovate performs upgrades for Sourcegraph Docker images based on a psuedo-versioning scheme that interprets this tag as `v0.YYYY.BUILD`.
 
-- If you want to update them manually, you can update the Docker image versions in `*.Deployment.yaml` to match the tagged version that you are releasing.
+Release branches (`3.19`, etc) track specific versions instead.
 
-  - You should look at our [DockerHub repositories](https://hub.docker.com/r/sourcegraph/) to see what the latest versions are.
+### Cutting a release
 
-  - Make sure to include the sha256 digest for each image, which [ensures that each image pull is immutable](https://renovatebot.com/docs/docker/#digest-pinning). Use `docker inspect --format='{{index .RepoDigests 0}}' $IMAGE` to get the digest.
+The [GitHub Action "Update tags"](https://github.com/sourcegraph/deploy-sourcegraph/actions?query=workflow%3A%22Dispatch+update%22) is used to enforce semver constraints for Sourcegraph Docker images for appropriate release branches (`3.19`, etc). Click "Run workflow" and provide the necessary parameters to open a pull request. You can run the workflow locally as well:
+
+```sh
+.github/workflows/scripts/update-docker-tags.sh "~3.19"
+```
+
+Once an upgrade is performed, tag the release. The version numbers for [sourcegraph/deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) largely follow [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)'s version numbers (i.e. `deploy-sourcegraph@v2.11.2` uses [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)'s `v2.11.2` image tags).
+
+Refer to [releases](https://about.sourcegraph.com/handbook/engineering/releases) for more details.
+
+### Manual image updates
+
+In most cases, you should not do this in `deploy-sourcegraph` itself, but in relevant forks instead - see the [installation](https://docs.sourcegraph.com/admin/install/kubernetes) guide.
+
+If you want to update Docker images manually, you can update the Docker image versions in `*.Deployment.yaml` to match the tagged version that you are releasing. You should look at our [DockerHub repositories](https://hub.docker.com/r/sourcegraph/) to see what the latest versions are. Make sure to include the sha256 digest for each image, which [ensures that each image pull is immutable](https://renovatebot.com/docs/docker/#digest-pinning). Use `docker inspect --format='{{index .RepoDigests 0}}' $IMAGE` to get the digest.
+
+## Testing changes
 
 ### Open a PR
 
@@ -22,17 +51,15 @@ Wait for buildkite to pass and for your changes to be approved, then merge and c
 
 Test what is currently checked in to master by [installing](docs/install.md) Sourcegraph on a fresh cluster.
 
-#### Provision a cluster and install Sourcegraph
+#### Using the sourcegraph/deploy-k8s-helper tool
 
-##### Using the sourcegraph/deploy-k8s-helper tool
+Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8s-helper) to your machine and follow the [README](https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) to set up all the prerequisistes.
 
-Clone https://github.com/sourcegraph/deploy-k8s-helper to your machine and follow the [README](https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) to set up all the prerequisistes. 
-
-###### Do smoke tests for `master` branch
+##### Do smoke tests for `master` branch
 
 1. Ensure that the `deploySourcegraphRoot` value in your stack configuration (see https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) is pointing to your deploy-sourcegraph checkout (ex: `pulumi config set deploySourcegraphRoot /Users/ggilmore/dev/go/src/github.com/sourcegraph/deploy-sourcegraph`)
-1. In your deploy-sourcegraph checkout, make sure that you're on  the latest `master`
-1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout 
+1. In your deploy-sourcegraph checkout, make sure that you're on the latest `master`
+1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout
 1. It'll take a few minutes for the cluster to be provisioned and for sourcegraph to be installed. Pulumi will show you the progresss that it's making, and will tell you when it's done. 
 1. Use the instructions in [configure.md](docs/configure.md) to:
    1. Add a repository (e.g. [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph))
@@ -40,26 +67,21 @@ Clone https://github.com/sourcegraph/deploy-k8s-helper to your machine and follo
    1. Do a few test searches
 1. When you're done, run `yarn destroy` to tear the cluster down. This can take ~10 minutes.
 
-###### Check the upgrade path from the previous release to `master`
+##### Check the upgrade path from the previous release to `master`
 
 1. In your deploy-sourcegraph checkout, checkout the commit that contains the configuration for the previous release (e.g. the commit that has `2.11.x` images if you're currently trying to release `2.12.x`, etc.)
-1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout 
+1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout
 1. Do [the same smoke tests that you did above](#Do-smoke-tests-for-master-branch)
-1. In your deploy-sourcegraph checkout, checkout the latest `master` commit again and run `yarn up` to deploy the new images. Check to see that [the same smoke tests](#Do-smoke-tests-for-master-branch) pass after the upgrade process. 
+1. In your deploy-sourcegraph checkout, checkout the latest `master` commit again and run `yarn up` to deploy the new images. Check to see that [the same smoke tests](#Do-smoke-tests-for-master-branch) pass after the upgrade process.
 1. When you're done, run `yarn destroy` to tear the cluster down.
 
-##### Manual instructions
+#### Manual instructions
 
-###### Provision a new cluster
+##### Provision a new cluster
 
-1.  Create a cluster unique name that is identifiable to you (e.g `ggilmore-test`) in the [Sourcegraph Auxiliary GCP Project](https://console.cloud.google.com/kubernetes/list?project=sourcegraph-server&organizationId=1006954638239).
-    - You can create a pool that has `4` nodes, each with `8` vCPUs and `30` GB memory (for a total of `32` vCPUs and `120` GB memory).
-    - See this screenshot, but note that the UI could have changed: ![](https://imgur.com/RuCyGX2.png)
-1.  It’ll take a few minutes for it to be provisioned. You’ll see a green checkmark when it is done.
-1.  Click on the `connect` button next to your cluster, it’ll give you a command to copy+paste in your terminal.
-1.  Run the command in your terminal. Once it finishes, run `kubectl config current-context`. It should tell you that it’s set up to talk to the cluster that you just created.
+Refer to [how to deploy a test cluster](https://about.sourcegraph.com/handbook/engineering/deployments#test-clusters).
 
-###### Do smoke tests for `master` branch
+##### Do smoke tests for `master` branch
 
 1. Deploy the latest `master` to your new cluster by running through the quickstart steps in [docs/install.md](docs/install.md)
    - You'll need to create a GCP Storage Class named `sourcegraph` with the same `zone` that you created your cluster in (see ["Configure a storage class"](docs/configure.md#Configure-a-storage-class))
@@ -69,7 +91,7 @@ Clone https://github.com/sourcegraph/deploy-k8s-helper to your machine and follo
    1. Enable a language extension (e.g. [Go](https://sourcegraph.com/extensions/sourcegraph/lang-go)), and test that code intelligence is working on the above repository
    1. Do a couple test searches
 
-###### Check the upgrade path from the previous release to `master`
+##### Check the upgrade path from the previous release to `master`
 
 1. Tear down the cluster that you created above by deleting it through from the [Sourcegraph Auxiliary GCP Project](https://console.cloud.google.com/kubernetes/list?project=sourcegraph-server&organizationId=1006954638239).
 1. Checkout the commit that contains the configuration for the previous release (e.g. the commit has `2.11.x` images if you're currently trying to release `2.12.x`, etc.)
@@ -77,13 +99,7 @@ Clone https://github.com/sourcegraph/deploy-k8s-helper to your machine and follo
 1. Deploy the older commit to the new cluster, and do [the same smoke tests](#Do-smoke-tests-for-master-branch) with the older version.
 1. Checkout the latest `master`, deploy the newer images to the same cluster (without tearing it down in between) by running `./kubectl-apply-all.sh`, and check to see [that the smoke test](#Do-smoke-tests-for-master-branch) passes after the upgrade process.
 
-### Tag the release
-
-The version numbers for [sourcegraph/deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) largely follow [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)'s version numbers (i.e. `deploy-sourcegraph@v2.11.2` uses [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph)'s `v2.11.2` image tags).
-
-#### [sourcegraph/deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)'s branching strategy
-
-## Minikube
+### Minikube
 
 You can use minikube to run Sourcegraph Cluster on your development machine. However, due to minikube requirements and reduced available resources we need to modify the resources to remove `resources` requests/limits and `storageClassNames`. Here is the shell commands you can use to spin up minikube:
 
@@ -108,4 +124,4 @@ kubectl edit deployment/repo-updater # set imagePullPolicy to Never
 kubectl set image deployment repo-updater '*=repo-updater:dev'
 ```
 
-You can also use the [minikube overlay](overlays/minikube/README.md). This avoids modifying the config files in `base`. 
+You can also use the [minikube overlay](overlays/minikube/README.md). This avoids modifying the config files in `base`.

--- a/README.dev.md
+++ b/README.dev.md
@@ -19,9 +19,9 @@
 
 Refer to [deployment basics](https://about.sourcegraph.com/handbook/engineering/deployments#deployment-basics) to learn about Sourcegraph Docker images and [Renovate](https://renovatebot.com/docs/docker/), which performs most image updates.
 
-The `master` branch of this repository is configured to track the latest builds from `sourcegraph/sourgraph@main`, tagged as `BUILD_YYYY_MM_DD_HASH`. Renovate performs upgrades for Sourcegraph Docker images based on a psuedo-versioning scheme that interprets this tag as `v0.YYYY.BUILD`.
+The `master` branch of this repository is configured to track the latest builds from `sourcegraph/sourgraph@main`, tagged as `insiders`. Renovate automatically performs updates for these images.
 
-Release branches (`3.19`, etc) track specific versions instead.
+Release branches (`3.19`, etc) track specific versions instead, and updates are triggered manually for specific branches - see [cutting a release](#cutting-a-release).
 
 ### Cutting a release
 

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.19.2@sha256:76276b4b464154d0329c7d960fdfcb2c627784a0e809243cc53d3e5dea6f19c8
+        image: index.docker.io/sourcegraph/cadvisor:72811_2020-09-07_923c6ae
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/cadvisor:72811_2020-09-07_923c6ae@sha256:def8f1a9d2f374657283aa7ce07e8bda7685b9f84736b51799138f614b70dae4
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:72811_2020-09-07_923c6ae@sha256:def8f1a9d2f374657283aa7ce07e8bda7685b9f84736b51799138f614b70dae4
+        image: index.docker.io/sourcegraph/cadvisor:insiders@sha256:bc75bd8b6459bcdb33d0075a3f2a6f7d9e324b0dde91b118b4a4a28426afb8eb
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,7 +58,7 @@ spec:
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:3.19.2@sha256:776606b680d7ce4a5d37451831ef2414ab10414b5e945ed5f50fe768f898d23f
+        image: index.docker.io/sourcegraph/frontend:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -90,7 +90,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -58,7 +58,7 @@ spec:
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/frontend:72811_2020-09-07_923c6ae@sha256:5fe71785e4cea356171114322b977bc8f62d4bd4df1d5d03a67b9bb1cfbcc0f7
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -90,7 +90,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -59,7 +59,7 @@ spec:
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:72811_2020-09-07_923c6ae@sha256:5fe71785e4cea356171114322b977bc8f62d4bd4df1d5d03a67b9bb1cfbcc0f7
+        image: index.docker.io/sourcegraph/frontend:insiders@sha256:e783f01e68022bd4a8d35b7efa7744dea60062b3c13b2bda3bd5b7c4ba486ba7
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -91,7 +91,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:72811_2020-09-07_923c6ae@sha256:cfcf913f027f83f09e2c2b4170f359a478ed5ef07a9b8f98eff387d9901371d1
+        image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:e21d72b58d8e966371bd1f0a4ae89a8dc5612ac2f16371e7ddae06c0a0c7a65a
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/github-proxy:72811_2020-09-07_923c6ae@sha256:cfcf913f027f83f09e2c2b4170f359a478ed5ef07a9b8f98eff387d9901371d1
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.19.2@sha256:bf435dd750c46840e2b45696577e0d94aac7a0afedf43428c2073a85c429843c
+        image: index.docker.io/sourcegraph/github-proxy:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.19.2@sha256:51b827ff2bf3f9df740cd8538840ef7fd7cb245c7b93063ef829f67ca71ea23e
+        image: index.docker.io/sourcegraph/gitserver:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:72811_2020-09-07_923c6ae@sha256:7256839dfb0d66bb914d47a4605e784fa8e131afaeaae45849cb58672f989ce2
+        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:7d5777089e5dae0abfa1cef2f5242cd3f1b197b01bbce4e8e897977468cf1404
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -52,7 +52,7 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/gitserver:72811_2020-09-07_923c6ae@sha256:7256839dfb0d66bb914d47a4605e784fa8e131afaeaae45849cb58672f989ce2
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:72811_2020-09-07_923c6ae@sha256:9207d5865bb9075d5a73c172485319d0c9964773e80ebd32f047665c9b978456
+      - image: index.docker.io/sourcegraph/grafana:insiders@sha256:1faa904ea7d88cdc3def683580b83dfe7203b8d6a4933f83e5cd08869642c30b
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/grafana:72811_2020-09-07_923c6ae@sha256:9207d5865bb9075d5a73c172485319d0c9964773e80ebd32f047665c9b978456
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:3.19.2@sha256:0f363ceecf8d206b16afa16716365949c882016a040c3b04a0041252ff8dbb11
+      - image: index.docker.io/sourcegraph/grafana:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/indexed-searcher:72811_2020-09-07_923c6ae@sha256:d2e87635cf48c4c5d744962540751022013359bc00a9fb8e1ec2464cc6a0a2b8
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/search-indexer:72811_2020-09-07_923c6ae@sha256:7ddeb4d06a89e086506f08d9a114186260c7fa6c242e59be8c28b505d506047a
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:3.19.2@sha256:d2e87635cf48c4c5d744962540751022013359bc00a9fb8e1ec2464cc6a0a2b8
+        image: index.docker.io/sourcegraph/indexed-searcher:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:3.19.2@sha256:7ddeb4d06a89e086506f08d9a114186260c7fa6c242e59be8c28b505d506047a
+        image: index.docker.io/sourcegraph/search-indexer:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:72811_2020-09-07_923c6ae@sha256:d2e87635cf48c4c5d744962540751022013359bc00a9fb8e1ec2464cc6a0a2b8
+        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:bdca7d7fdba637e7e8b41ebf4e51dfb81f4e8ea939f3c22a342cd894a4372bd7
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -48,7 +48,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:72811_2020-09-07_923c6ae@sha256:7ddeb4d06a89e086506f08d9a114186260c7fa6c242e59be8c28b505d506047a
+        image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:6624c1d0f243e3d2ed854baa0351c24d238be681f71692ec044cadca59f21114
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.19.2@sha256:fe04ae824252cb7bfb7047242d5f5da3a8491681b4007213c5d989d761f226ca
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:72811_2020-09-07_923c6ae
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:72811_2020-09-07_923c6ae
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:72811_2020-09-07_923c6ae@sha256:74ac83878156940528ffb1f87f0af322d603775efb921f644033dd0269deaab1
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:72811_2020-09-07_923c6ae@sha256:74ac83878156940528ffb1f87f0af322d603775efb921f644033dd0269deaab1
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:6293827e3f8950b758ad0a5f628c2678fabf05fd223388dc3d9eed3a6d400b00
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
       - name: correct-data-dir-permissions
-        image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+        image: sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
         command: ["sh", "-c", "if [ -d /data/pgdata-11 ]; then chmod 750 /data/pgdata-11; fi"]
         volumeMounts:
         - mountPath: /data
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/postgres-11.4:72811_2020-09-07_923c6ae@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.19.2@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+        image: index.docker.io/sourcegraph/postgres-11.4:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:72811_2020-09-07_923c6ae@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+        image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:72811_2020-09-07_923c6ae@sha256:5b0bb123aa0329246eacdfbffb11714ba32fe6b5df8e36eccf46fb5f9ddd55da
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:3.19.2@sha256:104b10b85cd508e31cc71271a7a5153d7248d2ef28a8f08756875d863492e363
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/bundle-manager.Deployment.yaml
+++ b/base/precise-code-intel/bundle-manager.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:72811_2020-09-07_923c6ae@sha256:5b0bb123aa0329246eacdfbffb11714ba32fe6b5df8e36eccf46fb5f9ddd55da
+        image: index.docker.io/sourcegraph/precise-code-intel-bundle-manager:insiders@sha256:e4675a7a154fbefc62e2a19b474d149f787e8fad60d39347681104212cf12542
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-bundle-manager
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.19.2@sha256:a1f5e4589cf09995d67cca1156749a371d24d8af9f1171808df1d39d6b6f1df6
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:72811_2020-09-07_923c6ae@sha256:723ff10ded0eb9d34ddac6da62d478923f70a4ac4fba67fe434a7811e38fb4cc
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:53541d66c419a34a5e3289e7b54926ba2f490e9a7f72e66522fbd15929c9c6e2
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:72811_2020-09-07_923c6ae@sha256:723ff10ded0eb9d34ddac6da62d478923f70a4ac4fba67fe434a7811e38fb4cc
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:3.19.2@sha256:be6b68a89bdf4b4b60ed61a1545179b20f91db8ba11e60869aaa00720b7c0e7b
+      - image: index.docker.io/sourcegraph/prometheus:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:72811_2020-09-07_923c6ae@sha256:60583ff59260e1b31c0f94896af34b17697b02f2e393e2d6826d6a7650ccf021
+      - image: index.docker.io/sourcegraph/prometheus:insiders@sha256:e2572e2a8adece9ff750bd19b14aacc51172482f6c7682217604deb46b90ce7d
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/prometheus:72811_2020-09-07_923c6ae@sha256:60583ff59260e1b31c0f94896af34b17697b02f2e393e2d6826d6a7650ccf021
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/query-runner:72811_2020-09-07_923c6ae@sha256:ba9c550052c7f17792273024b31794df5f8176e89a8916781696fcd2d233cd6b
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:72811_2020-09-07_923c6ae@sha256:ba9c550052c7f17792273024b31794df5f8176e89a8916781696fcd2d233cd6b
+        image: index.docker.io/sourcegraph/query-runner:insiders@sha256:c5422157c4126f4c09e0199e3ccb2d11cef0da9d147af86a5dfa0b3304b7823a
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.19.2@sha256:bdf87a86c751774dc7940ed3f4bd0a508e24e06630b1b8874d1dc43b1263969f
+        image: index.docker.io/sourcegraph/query-runner:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:72811_2020-09-07_923c6ae@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/redis-cache:72811_2020-09-07_923c6ae@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:3.19.2@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:72811_2020-09-07_923c6ae@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/redis-store:72811_2020-09-07_923c6ae@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:3.19.2@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.19.2@sha256:c135cd1efd3731c3cc0cc03f205147917110240650888e538fdbe325a552caff
+      - image: index.docker.io/sourcegraph/repo-updater:72811_2020-09-07_923c6ae
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -51,7 +51,7 @@ spec:
           requests:
             cpu: "1"
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/repo-updater:72811_2020-09-07_923c6ae@sha256:7a3298d8b2a0bfd5fb8d19ee46ca71ac65c9d93bb97260e3ec07a1d4f331b04a
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -51,7 +51,7 @@ spec:
           requests:
             cpu: "1"
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:72811_2020-09-07_923c6ae@sha256:7a3298d8b2a0bfd5fb8d19ee46ca71ac65c9d93bb97260e3ec07a1d4f331b04a
+      - image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:9c22713022e77815e5453b996af35a5b4fad394cf955640482efb238eb5d7bc2
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -52,7 +52,7 @@ spec:
           requests:
             cpu: "1"
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.19.2@sha256:96c83aa499031c3811cac30f2c0637f00873125b465708495e018d7e2cca680a
+        image: index.docker.io/sourcegraph/searcher:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -61,7 +61,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/searcher:72811_2020-09-07_923c6ae@sha256:a3ce4d8b8e1bcc2adb03aff76912d7444f021759183afdc777fdcc7c52304d90
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -61,7 +61,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:72811_2020-09-07_923c6ae@sha256:a3ce4d8b8e1bcc2adb03aff76912d7444f021759183afdc777fdcc7c52304d90
+        image: index.docker.io/sourcegraph/searcher:insiders@sha256:bf6c27dac159cbfbb2e348891976fce81a002c36637da9f86d2a8172d113a245
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -62,7 +62,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/symbols:72811_2020-09-07_923c6ae@sha256:3fc8614950ef057a57195f2aed73dca47ec3cf5bb5f607b42422ba187e5254a8
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.19.2@sha256:4254ec07804e84ab8b9b63fca906122c8501e3678978b818fe20dc3ec0344efd
+        image: index.docker.io/sourcegraph/symbols:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.19.2@sha256:e757094c04559780dba1ded3475ee5f0e4e5330aa6bbc8a7398e7277b0e450fe
+      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:72811_2020-09-07_923c6ae@sha256:3fc8614950ef057a57195f2aed73dca47ec3cf5bb5f607b42422ba187e5254a8
+        image: index.docker.io/sourcegraph/symbols:insiders@sha256:d4b4adfc982dc738e9c2aeac072c1efec635f97c983e43c42947bc11eab98f17
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -68,7 +68,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:72811_2020-09-07_923c6ae@sha256:b22323610059cc7e5fcdcfc61256bb949fe3a23cf9a7716147dfa0fa75e4ea8b
+      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:65d5cab29b7d92ce42e44c29af09890cf3499304951e21c067ff8e0b57872feb
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:72811_2020-09-07_923c6ae
+        image: index.docker.io/sourcegraph/syntax-highlighter:72811_2020-09-07_923c6ae@sha256:07b9f1ff4bd2c60299f9404144cd72897fa4de2308d1be65c35bcdcd10e5410d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.19.2@sha256:625c556f5cf456144e51e3fe55e6312398b7714994165b4f605711e6f7d862a0
+        image: index.docker.io/sourcegraph/syntax-highlighter:72811_2020-09-07_923c6ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:72811_2020-09-07_923c6ae@sha256:07b9f1ff4bd2c60299f9404144cd72897fa4de2308d1be65c35bcdcd10e5410d
+        image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:07b9f1ff4bd2c60299f9404144cd72897fa4de2308d1be65c35bcdcd10e5410d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,6 @@
     {
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "versioning": "regex:^(?<patch>\\d+)(\\_(?<minor>\\d+)\\-)",
-      "baseBranchList": ["master"],
       "ignoreUnstable": false,
       "semanticCommits": false,
       "automerge": false

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "prHourlyLimit": 0,
   "masterIssue": true,
   "pinDigests": true,
-  "baseBranches": ["master", "release"],
+  "baseBranches": ["master"],
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
@@ -16,14 +16,6 @@
       "baseBranchList": ["master"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": false
-    },
-    {
-      "groupName": "Sourcegraph Docker release images",
-      "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "baseBranchList": ["release"],
-      "versioning": "semver",
-      "ignoreUnstable": false,
       "automerge": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "prHourlyLimit": 0,
   "masterIssue": true,
   "pinDigests": true,
-  "baseBranches": ["master"],
+  "baseBranches": ["master", "release"],
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
@@ -12,15 +12,17 @@
     {
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
+      "versioning": "regex:^(?<patch>\\d+)(\\_(?<minor>\\d+)\\-)",
+      "baseBranchList": ["master"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "allowedVersions": "/^insiders$/",
       "automerge": false
     },
     {
       "groupName": "Sourcegraph Docker release images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
-      "versionScheme": "semver",
+      "baseBranchList": ["release"],
+      "versioning": "semver",
       "ignoreUnstable": false,
       "automerge": false
     },


### PR DESCRIPTION
Another stab at https://github.com/sourcegraph/sourcegraph/issues/13122 because Renovate is a bit of a bummer. Also see [new rendered docs](https://github.com/sourcegraph/deploy-sourcegraph/blob/switch-to-insiders/README.dev.md).

* ~Use `BUILD_YYYY` versioning scheme to track `insiders` - have Renovate interpret these versions as `v0.YYYY.BUILD` and upgrade accordingly, where `BUILD` is the Buildkite build number. Makes it more clear what is deployed. I'm happy to roll this back too, since I was having trouble getting Renovate to play well with `insiders` and performing releases, but now that I've dropped Renovate for generating releases, it should be fine to have `insiders` like we do on dot-com. See the current state of versions for what this might look like, and see the `"versioning"` option in `renovate.json` for how the versions are captured.~ **update** decided to just stick to `insiders` for now
* Use a manually triggered GitHub action to generate a release - this will be available through the Actions UI, and I'll document accordingly in https://github.com/sourcegraph/about/pull/1517. Also see https://github.com/slimsag/update-docker-tags/pull/7. You basically provide a Semver constraint and a branch to update, and a PR will be opened
   * Images are defined by hand - I tried an approach with a more generic approach to update all Sourcegraph images, but we have some versioning inconsistencies that made things a bit difficult, so I gave up on that (https://github.com/bobheadlabs/update-docker-tags/commit/38ab3ab34faa97fa18b80a4d3ae76bde9c3d14e9). You can try out what the Action does locally:

```
❯ .github/workflows/scripts/update-docker-tags.sh "~3.19"
base/cadvisor/cadvisor.DaemonSet.yaml
         sourcegraph/cadvisor            3.19.2
base/frontend/sourcegraph-frontend.Deployment.yaml
         sourcegraph/frontend            3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/github-proxy/github-proxy.Deployment.yaml
         sourcegraph/github-proxy                3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/gitserver/gitserver.StatefulSet.yaml
         sourcegraph/gitserver           3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/grafana/grafana.StatefulSet.yaml
         sourcegraph/grafana             3.19.2
base/indexed-search/indexed-search.StatefulSet.yaml
         sourcegraph/indexed-searcher            3.19.2
         sourcegraph/search-indexer              3.19.2
base/jaeger/jaeger.Deployment.yaml
         sourcegraph/jaeger-all-in-one           3.19.2
base/pgsql/pgsql.Deployment.yaml
         sourcegraph/alpine              3.12
         sourcegraph/postgres-11.4               3.19.2
base/precise-code-intel/bundle-manager.Deployment.yaml
         sourcegraph/precise-code-intel-bundle-manager           3.19.2
base/precise-code-intel/worker.Deployment.yaml
         sourcegraph/precise-code-intel-worker           3.19.2
base/prometheus/prometheus.Deployment.yaml
         sourcegraph/prometheus                  3.19.2
base/query-runner/query-runner.Deployment.yaml
         sourcegraph/query-runner                3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/redis/redis-cache.Deployment.yaml
         sourcegraph/redis-cache                 3.19.2
         sourcegraph/redis_exporter              18-02-07_bb60087_v0.15.0
base/redis/redis-store.Deployment.yaml
         sourcegraph/redis-store                 3.19.2
         sourcegraph/redis_exporter              18-02-07_bb60087_v0.15.0
base/repo-updater/repo-updater.Deployment.yaml
         sourcegraph/repo-updater                3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/searcher/searcher.Deployment.yaml
         sourcegraph/searcher            3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/symbols/symbols.Deployment.yaml
         sourcegraph/symbols             3.19.2
         sourcegraph/jaeger-agent                3.19.2
base/syntect-server/syntect-server.Deployment.yaml
         sourcegraph/syntax-highlighter                  72811_2020-09-07_923c6ae
```

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
