### PR TITLE
renovate: enable automerge for sourcegraph insiders

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": false
+      "automerge": true
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/13122

Renovate is rolling: https://github.com/sourcegraph/deploy-sourcegraph/pull/859

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
