### PR TITLE
renovate: add weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "packageRules": [
     {
       "groupName": "Sourcegraph Docker insiders images",


### PR DESCRIPTION
Reduce noise from renovate cloud, since we now have a [custom renovate trigger for this repository in sourcegraph/sourcegraph ](https://github.com/sourcegraph/sourcegraph/blob/main/.github/workflows/renovate-downstream.yml), which will override this schedule (https://github.com/sourcegraph/sourcegraph/pull/13761).

Also, this is partly because there doesn't seem to be a good way to exclude certain repositories from renovate cloud

Thinking it might be best to keep a weekly run as a fallback


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
