### PR TITLE
renovate: move schedule to packageRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,16 +8,16 @@
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
-  "schedule": [
-    "before 3am on Monday"
-  ],
   "packageRules": [
     {
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": true
+      "automerge": true,
+      "schedule": [
+        "before 3am on Monday"
+      ]
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Config not getting overwritten at the top level: https://github.com/sourcegraph/sourcegraph/runs/1107121150?check_suite_focus=true#step:5:368 , and no PRs are getting triggered

I can find no issues/documentation on this problem, even though all the docs indicate that the current set up should work 🤔 

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
