### PR TITLE
Revert "renovate: move schedule to packageRules"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,16 +8,16 @@
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "packageRules": [
     {
       "groupName": "Sourcegraph Docker insiders images",
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": true,
-      "schedule": [
-        "before 3am on Monday"
-      ]
+      "automerge": true
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Reverts sourcegraph/deploy-sourcegraph#864 - didn't do anything