### PR TITLE
move image field one line to avoid conflict on image update

### DIFF
--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -52,8 +52,8 @@ spec:
         # about configuring gitserver to use an SSH key
         # - mountPath: /root/.ssh
         #   name: ssh
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:cd3c94282770a16d1ca10723df522dfd46400863eb5cb8b105a61eee76185838
-        name: jaeger-agent
+      - name: jaeger-agent
+        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:cd3c94282770a16d1ca10723df522dfd46400863eb5cb8b105a61eee76185838
         env:
           - name: POD_NAME
             valueFrom:


### PR DESCRIPTION
Anyone who configures gitserver to use an SSH might be encountering a conflict here all the time whenever `jaeger-agent` is updated - see https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pull/35/commits/bce416e6fb8ba98e922e0c126dd452c7da6ac9b3#diff-0af75dcdf933574bfb06b86a1d41238e

This PR moves the image definition down one line to hopefully reduce the chance it'll conflict again


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
