### PR TITLE
lsif: disable workflow on renovate docker insiders branches

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -1,6 +1,9 @@
 name: LSIF
 on:
-  - push
+  push:
+    branches-ignore:
+      - 'renovate/docker-sourcegraph-docker-insiders-images'
+
 jobs:
   lsif-go:
     if: github.repository == 'sourcegraph/deploy-sourcegraph'


### PR DESCRIPTION
Based on frequency of commits to Sourcegraph, these can behave strangely on the renovate insiders branches (which tries to pick up the latest images as soon as possible)


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
