### PR TITLE
Use automerge action instead of renovate merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,3 +1,4 @@
+# based on https://github.com/pascalgn/automerge-action/tree/v0.9.0#usage
 name: automerge
 on:
   pull_request:
@@ -25,3 +26,4 @@ jobs:
         uses: pascalgn/automerge-action@v0.9.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: squash

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.9.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,5 @@
 # based on https://github.com/pascalgn/automerge-action/tree/v0.9.0#usage
-name: automerge
+name: Automerge
 on:
   pull_request:
     types:

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": true
+      "labels": ["automerge"]
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Renovate merge requires a renovate run, but we can typically merge as soon as CI finishes (ie before the next renovate run). This will reduce time-to-update from Sourcegraph to deploy-sourcegraph


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
