### PR TITLE
Use automerge action instead of renovate merge (take 2)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,5 +25,6 @@ jobs:
       - name: automerge
         uses: pascalgn/automerge-action@v0.9.0
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # Allows this merge to trigger other actions
+          GITHUB_TOKEN: "${{ secrets.DISPATCH_PERSONAL_ACCESS_TOKEN }}"
           MERGE_METHOD: squash

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+# based on https://github.com/pascalgn/automerge-action/tree/v0.9.0#usage
+name: Automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.9.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: squash

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "packagePatterns": ["^index.docker.io/sourcegraph/"],
       "ignoreUnstable": false,
       "semanticCommits": false,
-      "automerge": true
+      "labels": ["automerge"]
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
Brings back https://github.com/sourcegraph/deploy-sourcegraph/pull/886

This should work now that I've set the buildkite to be a required check

> Renovate merge requires a renovate run, but we can typically merge as soon as CI finishes (ie before the next renovate run). This will reduce time-to-update from Sourcegraph to deploy-sourcegraph

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
