### PR TITLE
ClusterRole namespaces

### DIFF
--- a/base/cadvisor/README.md
+++ b/base/cadvisor/README.md
@@ -5,3 +5,8 @@
 cAdvisor is part of the default Sourcegraph cluster installation, and deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). This setup is based on the [official cAdvisor Kubernetes Daemonset configuration](https://github.com/google/cadvisor/tree/master/deploy/kubernetes). We use our own cAdvisor deployment over the built-in metrics exported by Kubernetes because the latter is often outdated and needs to be kept in sync with our [Docker-Compose deployments](https://docs.sourcegraph.com/admin/install/docker-compose). This setup allows us to have standard dashboards across all Sourcegraph deployments.
 
 Note that the `sourcegraph/cadvisor` Docker images come with a set of default flags to help reduce memory usage and load on Prometheus - see [our Dockerfile](https://github.com/sourcegraph/sourcegraph/blob/master/docker-images/cadvisor/Dockerfile) for more details.
+
+## Namespaces
+
+If you are deploying Sourcegraph to a non-default namespace, you'll have to change the namespace specified in
+[cadvisor.ClusterRoleBinding.yaml](cadvisor.ClusterRoleBinding.yaml) to the one that you created. You can do this by editing the namespace directly, or by using the [namespaced overlay](../../configure/../overlays/namespaced/README.md).

--- a/base/prometheus/README.md
+++ b/base/prometheus/README.md
@@ -34,7 +34,7 @@ A Prometheus instance is part of the default Sourcegraph cluster installation.
 ## Namespaces
 
 If you are deploying Sourcegraph to a non-default namespace, you'll have to change the namespace specified in
- [prometheus.ClusterRoleBinding.yaml](prometheus.ClusterRoleBinding.yaml) to the one that you created.
+[prometheus.ClusterRoleBinding.yaml](prometheus.ClusterRoleBinding.yaml) to the one that you created. You can do this by editing the namespace directly, or by using the [namespaced overlay](../../configure/../overlays/namespaced/README.md).
 
 ## Making Prometheus accessible
 

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -23,6 +23,7 @@ spec:
         deploy: sourcegraph
         app: prometheus
     spec:
+      serviceAccountName: prometheus
       containers:
       - image: index.docker.io/sourcegraph/prometheus:insiders@sha256:96446e6b0a440892652e192f58e1011aea5df9e6d036c2f7e93632e88f516c38
         terminationMessagePolicy: FallbackToLogsOnError

--- a/overlays/namespaced/README.md
+++ b/overlays/namespaced/README.md
@@ -1,3 +1,5 @@
+# Namesapced
+
 This is a convenient kustomization that adds the specified namespace to all objects.
 
 If you replace `ns-sourcegraph` with your namespace value, make sure to do it in all the places in this directory tree.

--- a/overlays/namespaced/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/overlays/namespaced/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cadvisor
+subjects:
+  - kind: ServiceAccount
+    name: cadvisor
+    namespace: ns-sourcegraph

--- a/overlays/namespaced/kustomization.yaml
+++ b/overlays/namespaced/kustomization.yaml
@@ -7,3 +7,4 @@ bases:
   - ../bases/pvcs
 patchesStrategicMerge:
   - prometheus/prometheus.ClusterRoleBinding.yaml
+  - cadvisor/cadvisor.ClusterRoleBinding.yaml


### PR DESCRIPTION
The dogfood k8s environment is deployed in a namespace, `dogfood-k8s`, and Prometheus ran into two issues:

* there was no associated ServiceAccount - this change sets the service account explicitly, similar to what is done in the cAdvisor daemonset
* the service account was in the wrong namespace - there is a kustomization available for this, which I've updated to include an overlay for the cAdvisor account. I've also updated docs for both cAdvisor and Prometheus to indicate this.

See https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pull/98

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
