### PR TITLE
User implicit CI service account for tests

### DIFF
--- a/.buildkite/cleanup-unused-disks.sh
+++ b/.buildkite/cleanup-unused-disks.sh
@@ -3,7 +3,7 @@
 
 set -euxo pipefail
 
-SOURCEGRAPH_AUXILIARY_PROJECT=sourcegraph-server
+SOURCEGRAPH_AUXILIARY_PROJECT=sourcegraph-ci
 
 gcloud_command() {
   gcloud --quiet --project="$SOURCEGRAPH_AUXILIARY_PROJECT" "$@"

--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -6,7 +6,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
-export TEST_GCP_USERNAME=buildkite@sourcegraph-ci.iam.gserviceaccount.com
 # TODO(uwedeportivo): fix to comply with label restrictions (lowercase, less than 60, only _ and maybe others)
 # export BUILD_CREATOR="$(echo "$BUILDKITE_BUILD_CREATOR" | tr ' @./' '_' | tr 'A-Z' 'a-z')"
 export BUILD_CREATOR=unknown

--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
-export TEST_GCP_PROJECT=sourcegraph-server
+export TEST_GCP_PROJECT=sourcegraph-ci
 export TEST_GCP_ZONE=us-central1-a
 # TODO(uwedeportivo): fix to comply with label restrictions (lowercase, less than 60, only _ and maybe others)
 # export BUILD_CREATOR="$(echo "$BUILDKITE_BUILD_CREATOR" | tr ' @./' '_' | tr 'A-Z' 'a-z')"

--- a/.buildkite/integration-restricted-test.sh
+++ b/.buildkite/integration-restricted-test.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
-export TEST_GCP_USERNAME=buildkite@sourcegraph-dev.iam.gserviceaccount.com
+export TEST_GCP_USERNAME=buildkite@sourcegraph-ci.iam.gserviceaccount.com
 # TODO(uwedeportivo): fix to comply with label restrictions (lowercase, less than 60, only _ and maybe others)
 # export BUILD_CREATOR="$(echo "$BUILDKITE_BUILD_CREATOR" | tr ' @./' '_' | tr 'A-Z' 'a-z')"
 export BUILD_CREATOR=unknown

--- a/.buildkite/integration-test.sh
+++ b/.buildkite/integration-test.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 DEPLOY_SOURCEGRAPH_ROOT=$(pwd)
 export DEPLOY_SOURCEGRAPH_ROOT
 
-export TEST_GCP_PROJECT=sourcegraph-server
+export TEST_GCP_PROJECT=sourcegraph-ci
 export TEST_GCP_ZONE=us-central1-a
 
 BUILD_CREATOR="$(echo "${BUILDKITE_BUILD_CREATOR}" | tr ' /@.' '_' | tr '[:upper:]' '[:lower:]')"

--- a/.buildkite/integration-test.sh
+++ b/.buildkite/integration-test.sh
@@ -9,7 +9,7 @@ export DEPLOY_SOURCEGRAPH_ROOT
 
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
-export TEST_GCP_USERNAME=buildkite@sourcegraph-dev.iam.gserviceaccount.com
+export TEST_GCP_USERNAME=buildkite@sourcegraph-ci.iam.gserviceaccount.com
 
 BUILD_CREATOR="$(echo "${BUILDKITE_BUILD_CREATOR}" | tr ' /@.' '_' | tr '[:upper:]' '[:lower:]')"
 export BUILD_CREATOR

--- a/.buildkite/integration-test.sh
+++ b/.buildkite/integration-test.sh
@@ -9,7 +9,6 @@ export DEPLOY_SOURCEGRAPH_ROOT
 
 export TEST_GCP_PROJECT=sourcegraph-server
 export TEST_GCP_ZONE=us-central1-a
-export TEST_GCP_USERNAME=buildkite@sourcegraph-ci.iam.gserviceaccount.com
 
 BUILD_CREATOR="$(echo "${BUILDKITE_BUILD_CREATOR}" | tr ' /@.' '_' | tr '[:upper:]' '[:lower:]')"
 export BUILD_CREATOR

--- a/README.dev.md
+++ b/README.dev.md
@@ -60,7 +60,7 @@ Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8
 1. Ensure that the `deploySourcegraphRoot` value in your stack configuration (see https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) is pointing to your deploy-sourcegraph checkout (ex: `pulumi config set deploySourcegraphRoot /Users/ggilmore/dev/go/src/github.com/sourcegraph/deploy-sourcegraph`)
 1. In your deploy-sourcegraph checkout, make sure that you're on the latest `master`
 1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout
-1. It'll take a few minutes for the cluster to be provisioned and for sourcegraph to be installed. Pulumi will show you the progresss that it's making, and will tell you when it's done. 
+1. It'll take a few minutes for the cluster to be provisioned and for sourcegraph to be installed. Pulumi will show you the progresss that it's making, and will tell you when it's done.
 1. Use the instructions in [configure.md](docs/configure.md) to:
    1. Add a repository (e.g. [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph))
    1. Enable a language extension (e.g. [Go](https://sourcegraph.com/extensions/sourcegraph/lang-go)), and test that code intelligence is working on the above repository
@@ -93,7 +93,7 @@ Refer to [how to deploy a test cluster](https://about.sourcegraph.com/handbook/e
 
 ##### Check the upgrade path from the previous release to `master`
 
-1. Tear down the cluster that you created above by deleting it through from the [Sourcegraph Auxiliary GCP Project](https://console.cloud.google.com/kubernetes/list?project=sourcegraph-server&organizationId=1006954638239).
+1. Tear down the cluster that you created above by deleting it through from the [Sourcegraph CI GCP Project](https://console.cloud.google.com/kubernetes/list?project=sourcegraph-ci&organizationId=1006954638239).
 1. Checkout the commit that contains the configuration for the previous release (e.g. the commit has `2.11.x` images if you're currently trying to release `2.12.x`, etc.)
 1. [Use the "Provision a new cluster" instructions above](#Provision-a-new-cluster) to create a new cluster.
 1. Deploy the older commit to the new cluster, and do [the same smoke tests](#Do-smoke-tests-for-master-branch) with the older version.

--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -49,7 +49,6 @@ func commonConfig() (map[string]string, error) {
 	for env, key := range map[string]string{
 		"TEST_GCP_PROJECT":        "gcp:project",
 		"TEST_GCP_ZONE":           "gcp:zone",
-		"TEST_GCP_USERNAME":       "gcpUsername",
 		"DEPLOY_SOURCEGRAPH_ROOT": "deploySourcegraphRoot",
 		"BUILD_CREATOR":           "buildCreator",
 		"GENERATED_BASE":          "generatedBase",

--- a/tests/integration/fresh/step1/config.ts
+++ b/tests/integration/fresh/step1/config.ts
@@ -4,6 +4,5 @@ const config = new pulumi.Config()
 
 export const buildCreator = config.require('buildCreator')
 export const deploySourcegraphRoot = config.require('deploySourcegraphRoot')
-export const gcpUsername = config.require('gcpUsername')
 export const generatedBase = config.require('generatedBase')
 export const kubernetesVersionPrefix = config.require('kubernetesVersionPrefix')

--- a/tests/integration/fresh/step1/index.ts
+++ b/tests/integration/fresh/step1/index.ts
@@ -5,7 +5,7 @@ import * as fg from 'fast-glob'
 import * as k8s from '@pulumi/kubernetes'
 
 import { k8sProvider } from './cluster'
-import { deploySourcegraphRoot, gcpUsername, generatedBase } from './config'
+import { deploySourcegraphRoot, generatedBase } from './config'
 
 const storageClass = new k8s.storage.v1.StorageClass(
     'sourcegraph-storage-class',
@@ -41,7 +41,7 @@ const baseDeployment = baseFiles.then(
             },
             {
                 providers: { kubernetes: k8sProvider },
-                dependsOn: [clusterAdmin, storageClass],
+                dependsOn: [storageClass],
             }
         )
 )
@@ -58,7 +58,7 @@ const ingressNginx = ingressNginxFiles.then(
             {
                 files,
             },
-            { providers: { kubernetes: k8sProvider }, dependsOn: clusterAdmin }
+            { providers: { kubernetes: k8sProvider }}
         )
 )
 

--- a/tests/integration/fresh/step1/index.ts
+++ b/tests/integration/fresh/step1/index.ts
@@ -7,28 +7,6 @@ import * as k8s from '@pulumi/kubernetes'
 import { k8sProvider } from './cluster'
 import { deploySourcegraphRoot, gcpUsername, generatedBase } from './config'
 
-const clusterAdmin = new k8s.rbac.v1.ClusterRoleBinding(
-    'cluster-admin-role-binding',
-    {
-        metadata: { name: `${os.userInfo().username}-cluster-admin-role-binding` },
-
-        roleRef: {
-            apiGroup: 'rbac.authorization.k8s.io',
-            kind: 'ClusterRole',
-            name: 'cluster-admin',
-        },
-
-        subjects: [
-            {
-                apiGroup: 'rbac.authorization.k8s.io',
-                kind: 'User',
-                name: gcpUsername,
-            },
-        ],
-    },
-    { provider: k8sProvider }
-)
-
 const storageClass = new k8s.storage.v1.StorageClass(
     'sourcegraph-storage-class',
     {

--- a/tests/integration/fresh/step1/index.ts
+++ b/tests/integration/fresh/step1/index.ts
@@ -58,7 +58,7 @@ const ingressNginx = ingressNginxFiles.then(
             {
                 files,
             },
-            { providers: { kubernetes: k8sProvider }}
+            { providers: { kubernetes: k8sProvider } }
         )
 )
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -12,7 +12,6 @@ BUILD_BRANCH="${BUILD_BRANCH:-dev}"
 BUILD_UUID="${BUILD_UUID:-dev}"
 [ ! -z "$TEST_GCP_ZONE" ]
 [ ! -z "$TEST_GCP_PROJECT" ]
-[ ! -z "$TEST_GCP_USERNAME" ]
 
 CLEANUP=""
 trap 'bash -c "$CLEANUP"' EXIT
@@ -35,8 +34,6 @@ if [ -z "${NOCLEANUP:-}" ]; then
   CLUSTER_CLEANUP="gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
   CLEANUP="$CLUSTER_CLEANUP; $CLEANUP"
 fi
-
-kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user ${TEST_GCP_USERNAME}
 
 kubectl apply -f sourcegraph.StorageClass.yaml
 


### PR DESCRIPTION
Remove the explicit `dev` buildkite account definitiona and use the
account already associated with the GKE nodes which has the correct
permissions.

This change also uses `sourcegraph-ci` as the target project for
ephemeral test clusters.