### PR TITLE
cleanup of small warts in the manifest specification

### DIFF
--- a/base/frontend/sourcegraph-frontend.RoleBinding.yaml
+++ b/base/frontend/sourcegraph-frontend.RoleBinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: frontend
   name: sourcegraph-frontend
 roleRef:
-  apiGroup: ""
+  apiGroup: "rbac.authorization.k8s.io"
   kind: Role
   name: sourcegraph-frontend
 subjects:

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: prometheus
   name: prometheus
 roleRef:
-  apiGroup: ""
+  apiGroup: "rbac.authorization.k8s.io"
   kind: ClusterRole
   name: prometheus
 subjects:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -23,7 +23,6 @@ spec:
         deploy: sourcegraph
         app: prometheus
     spec:
-      serviceAccountName: prometheus
       containers:
       - image: index.docker.io/sourcegraph/prometheus:insiders@sha256:95169933dd2825c54bacc7035d5439c07e9745bcc54d2074717bb8f4160229ce
         terminationMessagePolicy: FallbackToLogsOnError

--- a/overlays/non-root/pgsql/pgsql.Deployment.yaml
+++ b/overlays/non-root/pgsql/pgsql.Deployment.yaml
@@ -19,3 +19,6 @@ spec:
           allowPrivilegeEscalation: false
           runAsUser: 999
           runAsGroup: 999
+      securityContext:
+        # Required to prevent escalations to root.
+        runAsUser: 999


### PR DESCRIPTION
- service account in prometheus specified twice
- api group for cluster role binding
- non-root security context for pgsql needs to override base one at top-level too (not just in container specs)