### PR TITLE
buildkite: fix verify-yaml script

### DIFF
--- a/.buildkite/verify-yaml.sh
+++ b/.buildkite/verify-yaml.sh
@@ -3,9 +3,9 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
+gcloud container clusters get-credentials dogfood --zone us-central1-f --project sourcegraph-dogfood
 
-kubectl apply --dry-run --validate --recursive -f base/ --context=gke_sourcegraph-dev_us-central1-a_dogfood
-kubectl apply --dry-run --validate --recursive -f configure/ --context=gke_sourcegraph-dev_us-central1-a_dogfood
+kubectl apply --dry-run --validate --recursive -f base/ --context=gke_sourcegraph-dogfood_us-central1-f_dogfood
+kubectl apply --dry-run --validate --recursive -f configure/ --context=gke_sourcegraph-dogfood_us-central1-f_dogfood
 
 .buildkite/verify-label.sh


### PR DESCRIPTION
Reflects @pecigonzalo 's change over at https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3516 back upstream to this repo. Currently blocking automated updates: https://github.com/sourcegraph/deploy-sourcegraph/pull/985

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
