### PR TITLE
Ignore dhall files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ generated/
 Pulumi.*.yaml
 /pkg/gen/openapi-specs
 generated-cluster/
+
+**/*.dhall

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ Pulumi.*.yaml
 /pkg/gen/openapi-specs
 generated-cluster/
 
-**/*.dhall
+/right.dhall


### PR DESCRIPTION
Ignore dhall files for security reasons (see [security issue 8](https://github.com/sourcegraph/security-issues/issues/8))

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/161) change:

<!-- add link or explanation of why it is not needed here -->
