### PR TITLE
prometheus: increase memory limit

### DIFF
--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -48,20 +48,18 @@ spec:
         - mountPath: /sg_prometheus_add_ons
           name: config
         # Prometheus is relied upon to monitor services for sending alerts to site admins when
-        # something is wrong with Sourcegraph, thus its memory requests and limits are the same to
-        # guarantee it has enough memory to perform its job reliably and prevent conflicts with
-        # other pods on the same host node.
+        # something is wrong with Sourcegraph, thus its memory requests are very high to guarantee
+        # it has enough memory to perform its job reliably and prevent conflicts with other pods
+        # on the same host node.
         #
-        # Its average memory usage may be much lower than 3G if Sourcegraph itself does not have
-        # much traffic, the 3G number chosen here is what works reliably on Sourcegraph.com with
-        # lots of traffic.
+        # The 8G limit chosen here is what works reliably on Sourcegraph.com with lots of traffic.
         resources:
           limits:
             cpu: "2"
-            memory: 3G
+            memory: 8G
           requests:
             cpu: 500m
-            memory: 3G
+            memory: 4G
       securityContext:
         runAsUser: 0
       serviceAccountName: prometheus

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -48,18 +48,19 @@ spec:
         - mountPath: /sg_prometheus_add_ons
           name: config
         # Prometheus is relied upon to monitor services for sending alerts to site admins when
-        # something is wrong with Sourcegraph, thus its memory requests are very high to guarantee
-        # it has enough memory to perform its job reliably and prevent conflicts with other pods
-        # on the same host node.
+        # something is wrong with Sourcegraph, thus its memory requests and limits are the same to
+        # guarantee it has enough memory to perform its job reliably and prevent conflicts with
+        # other pods on the same host node.
         #
-        # The 8G limit chosen here is what works reliably on Sourcegraph.com with lots of traffic.
+        # The limit chosen here is based on what works reliably on Sourcegraph.com with lots
+        # of traffic.
         resources:
           limits:
             cpu: "2"
-            memory: 8G
+            memory: 6G
           requests:
             cpu: 500m
-            memory: 4G
+            memory: 6G
       securityContext:
         runAsUser: 0
       serviceAccountName: prometheus


### PR DESCRIPTION
Prometheus in k8s.sgdev.org recently got itself in a OOMKilled CrashLoopBackoff (https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pull/229). It's not a very busy deployment, so this probably warrants a bump in the requirements.

The comment was also a bit outdated - Prometheus in Cloud now gets 8G, not the 3G claimed here, so I set a new limit at 8G.


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
