### PR TITLE
chore: use go run for update-docker-tags

### DIFF
--- a/.github/workflows/scripts/update-docker-tags.sh
+++ b/.github/workflows/scripts/update-docker-tags.sh
@@ -2,7 +2,8 @@
 
 CONSTRAINT=$1
 
-update-docker-tags \
+# Using `go run` ensures we are using the version of `update-docker-tags` pinned in `go.mod`
+go run github.com/slimsag/update-docker-tags \
   -enforce="sourcegraph/cadvisor=$CONSTRAINT" \
   -enforce="sourcegraph/frontend=$CONSTRAINT" \
   -enforce="sourcegraph/jaeger-agent=$CONSTRAINT" \

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           go-version: '^1.14'
 
-      # uses version pinned in go.mod
-      - name: Install update-docker-tags
-        run: go install github.com/slimsag/update-docker-tags
-
       # generate update
       - name: Pin tags to ${{ github.event.inputs.semver }}
         run: .github/workflows/scripts/update-docker-tags.sh "${{ github.event.inputs.semver }}"


### PR DESCRIPTION
This should fix https://github.com/sourcegraph/sourcegraph/issues/14925 by ensuring that the release tool user's local PATH/GO setup does not interfere with the correct update-docker-tags version that should be used


<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository.
-->

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:

<!-- add link or explanation of why it is not needed here -->
