### PR TITLE
Add MinIO deployment

### DIFF
--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    description: MinIO for storing LSIF uploads.
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: minio
+  name: minio
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        deploy: sourcegraph
+        app: minio
+    spec:
+      containers:
+      - env:
+        - name: MINIO_ACCESS_KEY
+          value: AKIAIOSFODNN7EXAMPLE
+        - name: MINIO_SECRET_KEY
+          value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        image: index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        terminationMessagePolicy: FallbackToLogsOnError
+        name: minio
+        ports:
+        - containerPort: 9000
+          name: minio
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: http
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: "1"
+            memory: 500M
+          requests:
+            cpu: "1"
+            memory: 500M
+        volumeMounts:
+        - mountPath: /data
+          name: minio-data
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: minio-data
+        persistentVolumeClaim:
+          claimName: minio

--- a/base/minio/minio.PersistentVolumeClaim.yaml
+++ b/base/minio/minio.PersistentVolumeClaim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: minio
+  name: minio
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: sourcegraph

--- a/base/minio/minio.Service.yaml
+++ b/base/minio/minio.Service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9000"
+    prometheus.io/path: "/minio/prometheus/metrics"
+    sourcegraph.prometheus/scrape: "true"
+  labels:
+    app: minio
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+    app.kubernetes.io/component: minio
+  name: minio
+spec:
+  ports:
+  - name: minio
+    port: 9000
+    targetPort: minio
+  selector:
+    app: minio
+  type: ClusterIP


### PR DESCRIPTION
This adds a MinIO deployment. Part of https://github.com/sourcegraph/sourcegraph/issues/14825.

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/169