### PR TITLE
Add environment variables to point to MinIO

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -69,6 +69,24 @@ spec:
           value: http://precise-code-intel-bundle-manager:3187
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
+        # If these variables are updated, they must also be updated in the
+        # precise-code-intel-worker deployment as well.
+        - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
+          value: S3
+        - name: PRECISE_CODE_INTEL_UPLOAD_BUCKET
+          value: lsif-uploads
+        - name: PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET
+          value: 'true'
+        - name: AWS_ACCESS_KEY_ID
+          value: 'AKIAIOSFODNN7EXAMPLE'
+        - name: AWS_SECRET_ACCESS_KEY
+          value: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+        - name: AWS_ENDPOINT
+          value: http://minio:9000
+        - name: AWS_REGION
+          value: us-east-1
+        - name: AWS_S3_FORCE_PATH_STYLE
+          value: 'true'
         image: index.docker.io/sourcegraph/frontend:insiders@sha256:77e6c79ed5d58ef9f1f8e651e3b05acc8f764c10dad26c9182cb55cbc633569f
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -77,15 +77,15 @@ spec:
           value: lsif-uploads
         - name: PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET
           value: 'true'
-        - name: AWS_ACCESS_KEY_ID
+        - name: PRECISE_CODE_INTEL_AWS_ACCESS_KEY_ID
           value: 'AKIAIOSFODNN7EXAMPLE'
-        - name: AWS_SECRET_ACCESS_KEY
+        - name: PRECISE_CODE_INTEL_AWS_SECRET_ACCESS_KEY
           value: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-        - name: AWS_ENDPOINT
+        - name: PRECISE_CODE_INTEL_AWS_ENDPOINT
           value: http://minio:9000
-        - name: AWS_REGION
+        - name: PRECISE_CODE_INTEL_AWS_REGION
           value: us-east-1
-        - name: AWS_S3_FORCE_PATH_STYLE
+        - name: PRECISE_CODE_INTEL_AWS_S3_FORCE_PATH_STYLE
           value: 'true'
         image: index.docker.io/sourcegraph/frontend:insiders@sha256:77e6c79ed5d58ef9f1f8e651e3b05acc8f764c10dad26c9182cb55cbc633569f
         terminationMessagePolicy: FallbackToLogsOnError

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -40,15 +40,15 @@ spec:
           value: lsif-uploads
         - name: PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET
           value: 'true'
-        - name: AWS_ACCESS_KEY_ID
+        - name: PRECISE_CODE_INTEL_AWS_ACCESS_KEY_ID
           value: 'AKIAIOSFODNN7EXAMPLE'
-        - name: AWS_SECRET_ACCESS_KEY
+        - name: PRECISE_CODE_INTEL_AWS_SECRET_ACCESS_KEY
           value: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-        - name: AWS_ENDPOINT
+        - name: PRECISE_CODE_INTEL_AWS_ENDPOINT
           value: http://minio:9000
-        - name: AWS_REGION
+        - name: PRECISE_CODE_INTEL_AWS_REGION
           value: us-east-1
-        - name: AWS_S3_FORCE_PATH_STYLE
+        - name: PRECISE_CODE_INTEL_AWS_S3_FORCE_PATH_STYLE
           value: 'true'
         - name: POD_NAME
           valueFrom:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -32,6 +32,24 @@ spec:
           value: '4'
         - name: PRECISE_CODE_INTEL_BUNDLE_MANAGER_URL
           value: http://precise-code-intel-bundle-manager:3187
+        # If these variables are updated, they must also be updated in the
+        # frontend deployment as well.
+        - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
+          value: S3
+        - name: PRECISE_CODE_INTEL_UPLOAD_BUCKET
+          value: lsif-uploads
+        - name: PRECISE_CODE_INTEL_UPLOAD_MANAGE_BUCKET
+          value: 'true'
+        - name: AWS_ACCESS_KEY_ID
+          value: 'AKIAIOSFODNN7EXAMPLE'
+        - name: AWS_SECRET_ACCESS_KEY
+          value: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+        - name: AWS_ENDPOINT
+          value: http://minio:9000
+        - name: AWS_REGION
+          value: us-east-1
+        - name: AWS_S3_FORCE_PATH_STYLE
+          value: 'true'
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
This PR directs the frontends and precise-code-intel-workers at the MinIO pods.

Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
