### PR TITLE
indexed-search: webserver with a higher watchdog threshold

### DIFF
--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,16 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:3.21.2@sha256:fcf03182a79aaf48252f74e47204088a2db4f11620c97dfbca0721f61521fe3c
+        # By default zoekt's watchdog tries 3 times before panicing. This ups
+        # the threshold to 10. If you want to disable the watchdog, set this
+        # value to "0".
+        - name: ZOEKT_WATCHDOG_ERRORS
+          value: "10"
+        # This insiders image is 3.21.2 with 4 extra backwards compatible
+        # commits. Importantly it includes tunables and instrumentation for
+        # the watchdog. See
+        # https://github.com/sourcegraph/sourcegraph/pull/15148
+        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:cb93574cd44feb34f223f45992cf8a2787970aac9b73e27d6a567457945d3918
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:


### PR DESCRIPTION
This commit is based off v3.21.2, but changes the zoekt version to have watchdog instrumentation and tuneables. See https://github.com/sourcegraph/sourcegraph/pull/15148

It tunes the watchdog to trigger after 10 failed attempts, instead of the default 3.

When upgrading to 3.22 (when released), you can switch back to the official images. If you want to keep the watchdog tuning, leave the environment variables in. They will be valid in 3.22.

We encourage you to first upgrade to 3.21, then to apply this change.

You can checkout this branch with `git fetch --all && git checkout k/3.21-watchdog`