### PR TITLE
Remove empty, invalid env blocks

### DIFF
--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -33,8 +33,7 @@ spec:
         securityContext:
           runAsUser: 0
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/codeintel-db@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
+      - image: index.docker.io/sourcegraph/codeintel-db@sha256:63090799b34b3115a387d96fe2227a37999d432b774a1d9b7966b8c5d81b56ad
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -27,8 +27,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:af19c210f8aa84f384af88c3afe3c116f39ae8c1d03476ccd5d133ff21787f0b
+      - image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:393565af0c84327c7e5089986fd6b3cdd8ebb3c2d8994605744ac61f2b16e0e8
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,8 +26,7 @@ spec:
       containers:
       - args:
         - run
-        env:
-        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:c431f66e0a4cee91e591ad218c194e7369e5666fad74878fda95c545901948e7
+        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:fab1532f017b77337e23263157a18b3bb1864eec1f9f5db94127b07b61a21c24
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -22,8 +22,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:c9d0a3488f3a6030153004c3f0e306c540290c3a5ebd33914be1931f9428485b
+      - image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:c9d0a3488f3a6030153004c3f0e306c540290c3a5ebd33914be1931f9428485b
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -47,8 +46,7 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: data
-      - env:
-        image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:eaaba3c9956d50a148c032cfeca57531d143359b3648f5ffbea8d3feb5cb5e81
+      - image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:eaaba3c9956d50a148c032cfeca57531d143359b3648f5ffbea8d3feb5cb5e81
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -34,8 +34,7 @@ spec:
         securityContext:
           runAsUser: 0
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+      - image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -27,8 +27,7 @@ spec:
         app: query-runner
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/query-runner:insiders@sha256:346fa3ba129db03786683373b9f6a28d2dc034a2d3dcab23366dd25f0bbfe6dd
+      - image: index.docker.io/sourcegraph/query-runner:insiders@sha256:7f4f3fec01aeabd3d0b6febecfd905af53a6e584b6141556b20451161da4705b
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -24,8 +24,7 @@ spec:
         app: redis-cache
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+      - image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -24,8 +24,7 @@ spec:
         app: redis-store
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+      - image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -28,8 +28,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:7d7e37d60298e12a23dc85f19a9140de4fb846effe1fabae764afd2c93fd8394
-        env:
+      - image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:1432b454d46822624de9321232f6674ba8561f9e2f2ace8fae84a6b41ed3f2dc
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
         ports:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -27,8 +27,7 @@ spec:
         app: syntect-server
     spec:
       containers:
-      - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185
+      - image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:e50ed88f971f7b08698abbc87a10fe18f2f8bbb6472766a15677621c59ca5185
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This PR fixes invalid K8S YAML - an empty `env` block is not legal Kubernetes config syntax, and I have to remove this set of invalid fields every time we do an update of Sourcegraph or the deployment fails.

I figured I'd just upstream the fix once and for all instead.