### PR TITLE
Update minio.Deployment to use 'args' instead of 'command'

### DIFF
--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
         image: index.docker.io/sourcegraph/minio@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
-        command: ['server', '/data']
+        args: ['server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         name: minio
         ports:


### PR DESCRIPTION
https://medium.com/faun/minio-object-storage-deployment-on-kubernetes-83f81fba1d03


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: Already in place https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/deploy-minio.sh#L25
* [ ] ~~If this change introduces a new service, add this service to `tools/update-docker-tags.sh`~~
