### PR TITLE
Fix the minio probes port reference

### DIFF
--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -39,14 +39,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /minio/health/live
-            port: http
+            port: minio
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /minio/health/live
-            port: http
+            port: minio
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5


### PR DESCRIPTION
The deployment is currently failing with 

```
Readiness probe errored: strconv.Atoi: parsing "http": invalid syntax | Unhealthy | Nov 12, 2020, 5:33:20 PM | Nov 12, 2020, 5:43:15 PM | 120 |  
Liveness probe errored: strconv.Atoi: parsing "http": invalid syntax | Unhealthy | Nov 12, 2020, 5:34:23 PM | Nov 12, 2020, 5:34:43 PM | 3 |  
```

I believe this is due to the port reference being incorrect.