### PR TITLE
releasing: note that step is done by release tool

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -25,6 +25,8 @@ Release branches (`3.19`, etc) track specific versions instead, and updates are 
 
 ### Cutting a release
 
+> ⚠️ If you are using the Sourcegraph release tooling, this step will be done for you in the PR it creates. Learn more about the release process in [the handbook](https://about.sourcegraph.com/handbook/engineering/releases).
+
 The [GitHub Action "Update tags"](https://github.com/sourcegraph/deploy-sourcegraph/actions?query=workflow%3A%22Dispatch+update%22) is used to enforce semver constraints for Sourcegraph Docker images for appropriate release branches (`3.19`, etc). Click "Run workflow" and provide the necessary parameters to open a pull request. You can run the workflow locally as well:
 
 ```sh


### PR DESCRIPTION
Just noticed this in passing

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: similar notes already exist on the relevant steps over there
* [ ] If this change introduces a new service, add this service to `tools/update-docker-tags.sh`
