### PR TITLE
pipeline: skip integration tests for image updates

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,17 +12,21 @@ steps:
 
   - wait
 
-  - label: ":pulumi: :k8s:"
+  # Integration test suites - run these on all pipelines except purely image updates
+
+  - label: ":pulumi::k8s: Integration test"
     concurrency: 3
     concurrency_group: deploy-sourcegraph/integration
     command: .buildkite/integration-test.sh
+    if: build.branch != 'renovate/docker-sourcegraph-docker-insiders-images'
     env:
       VERBOSE: "true"
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
 
-  - label: ":k8s:"
+  - label: ":lock::k8s: Restricted overlay integration test"
+    if: build.branch != 'renovate/docker-sourcegraph-docker-insiders-images'
     concurrency: 3
     concurrency_group: deploy-sourcegraph/integration-restricted
     command: .buildkite/integration-restricted-test.sh
@@ -31,10 +35,12 @@ steps:
       # are removed manually
       NOCLEANUP: "false"
 
+  # Cleanup steps
+
   - wait: ~
     continue_on_failure: true
   
-  - label: ":gcompute: :floppy_disk: 🧹"
+  - label: ":gcompute::floppy_disk::broom: Disk cleanup"
     concurrency: 1
     concurrency_group: deploy-sourcegraph/clean-unused-disks
     command: .buildkite/cleanup-unused-disks.sh


### PR DESCRIPTION
<!-- description here -->

Proposal to skip deploy-sourcegraph integration tests, since we run regression tests on cluster in `sourcegraph/sourcegraph`. That build is not yet blocking, but once it is (or if we update the Renovate trigger appropriately) we should be able to save some time on the deploy by not requiring this CI to pass.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] If this change introduces or removes a service, add this service to `tools/update-docker-tags.sh`
* [ ] All images have a valid tag and SHA256 sum
