### PR TITLE
feat(scripts): add a script to clean-up all kubernetes resources

### DIFF
--- a/kubectl-delete-all.sh
+++ b/kubectl-delete-all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# This file should contain `kubectl delete` commands for all of your configured resources.
+#
+# This file should be run:
+#   * When you want to clean-up all resources created
+#
+# Remove the base Soucegraph deployment
+# shellcheck disable=SC2068
+kubectl delete -f base --recursive $@


### PR DESCRIPTION
Summary:
There is `kubectl-apply-all.sh` already in place, however, there should
be a "delete-all" script present for more smooth playground scenarios in
real clusters.