### PR TITLE
tools: generate update-docker-tags args from sourcegraph/sourcegraph

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,4 @@
   this repository. If uneeded, add link or explanation of why it is not needed here.
 -->
 * [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
-* [ ] If this change introduces or removes a service, add this service to `tools/update-docker-tags.sh`
 * [ ] All images have a valid tag and SHA256 sum

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: pascalgn/automerge-action@v0.9.0
+        uses: pascalgn/automerge-action@v0.12.0
         env:
           # Allows this merge to trigger other actions
           GITHUB_TOKEN: "${{ secrets.DISPATCH_PERSONAL_ACCESS_TOKEN }}"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pulumi/pulumi v1.12.0
 	github.com/sethgrid/pester v1.1.0
 	github.com/slimsag/update-docker-tags v0.7.0
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5
 )
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,9 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/slimsag/update-docker-tags v0.7.0 h1:43SSOii74DpuQ3HK+AxHeE54tTFiUEz1xOsiI8hwymQ=
 github.com/slimsag/update-docker-tags v0.7.0/go.mod h1:T42NkUDP2MrfiSj3NT4JI27g/ksCngfCiY1goUQdIh0=
+github.com/sourcegraph/sourcegraph v0.0.0-20201129044102-91280e756de5 h1:uVixZOxbX8zdG4y1pM42lr75YBjEXBMmtewQ44bWO2M=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5 h1:K/ojwjaivMZ45jt3dslKka1ciZvMrGbRuofN/PESL5o=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "labels": ["automerge"]
     },
     {
+      "groupName": "Sourcegraph Docker images list",
+      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"],
+      "labels": ["automerge"]
+    },
+    {
       "groupName": "Pulumi NPM packages",
       "managers": ["npm"],
       "paths": ["tests/**"],

--- a/tools/enforce-tags/main.go
+++ b/tools/enforce-tags/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		log.Fatal("constraint, directory arguments must be provided")
+	}
+	var (
+		constraint = os.Args[1]
+		dir        = os.Args[2]
+	)
+	args := []string{
+		"run",
+		"github.com/slimsag/update-docker-tags",
+	}
+	for _, image := range images.SourcegraphDockerImages {
+		args = append(args, fmt.Sprintf("-enforce=sourcegraph/%s=%s", image, constraint))
+	}
+	args = append(args, dir)
+	log.Println(strings.Join(args, " "))
+
+	cmd := exec.Command("go", args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		log.Fatal((err))
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,6 @@
 package tools
 
 import (
-	// pins update-docker-tags CLI
+	// pins update-docker-tags CLI version
 	_ "github.com/slimsag/update-docker-tags"
 )

--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -1,28 +1,10 @@
 #!/bin/bash
 
+set -e
+
+root_dir="$(dirname "${BASH_SOURCE[0]}")/.."
+cd "$root_dir"
+
 CONSTRAINT=$1
 
-# Using `go run` ensures we are using the version of `update-docker-tags` pinned in `go.mod`
-go run github.com/slimsag/update-docker-tags \
-  -enforce="sourcegraph/cadvisor=$CONSTRAINT" \
-  -enforce="sourcegraph/frontend=$CONSTRAINT" \
-  -enforce="sourcegraph/jaeger-agent=$CONSTRAINT" \
-  -enforce="sourcegraph/github-proxy=$CONSTRAINT" \
-  -enforce="sourcegraph/gitserver=$CONSTRAINT" \
-  -enforce="sourcegraph/grafana=$CONSTRAINT" \
-  -enforce="sourcegraph/indexed-searcher=$CONSTRAINT" \
-  -enforce="sourcegraph/search-indexer=$CONSTRAINT" \
-  -enforce="sourcegraph/jaeger-all-in-one=$CONSTRAINT" \
-  -enforce="sourcegraph/postgres-11.4=$CONSTRAINT" \
-  -enforce="sourcegraph/precise-code-intel-worker=$CONSTRAINT" \
-  -enforce="sourcegraph/codeintel-db=$CONSTRAINT" \
-  -enforce="sourcegraph/syntax-highlighter=$CONSTRAINT" \
-  -enforce="sourcegraph/prometheus=$CONSTRAINT" \
-  -enforce="sourcegraph/query-runner=$CONSTRAINT" \
-  -enforce="sourcegraph/redis-cache=$CONSTRAINT" \
-  -enforce="sourcegraph/redis-store=$CONSTRAINT" \
-  -enforce="sourcegraph/repo-updater=$CONSTRAINT" \
-  -enforce="sourcegraph/searcher=$CONSTRAINT" \
-  -enforce="sourcegraph/symbols=$CONSTRAINT" \
-  -enforce="sourcegraph/minio=$CONSTRAINT" \
-  base/
+go run ./tools/enforce-tags "$CONSTRAINT" base/


### PR DESCRIPTION
<!-- description here -->

Generates update-docker-tag args from the master list over in `sourcegraph/sourcegraph` (https://github.com/sourcegraph/sourcegraph/pull/16227) instead of requiring manual maintenance. Closes https://github.com/sourcegraph/sourcegraph/issues/15896

As a reminder, we can't just wildcard `sourcegraph/*` images during version enforcement because we have images that don't conform to our standard versioning (e.g. `sourcegraph/alpine`)

The entrypoint remains the same, so this will not break our tooling/CI that now depends on the script.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/187
* [x] All images have a valid tag and SHA256 sum
