### PR TITLE
do not automerge images package updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pulumi/pulumi v1.12.0
 	github.com/sethgrid/pester v1.1.0
 	github.com/slimsag/update-docker-tags v0.7.0
-	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201201090328-3a2078e373f0
 )
 
 replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ github.com/slimsag/update-docker-tags v0.7.0/go.mod h1:T42NkUDP2MrfiSj3NT4JI27g/
 github.com/sourcegraph/sourcegraph v0.0.0-20201129044102-91280e756de5 h1:uVixZOxbX8zdG4y1pM42lr75YBjEXBMmtewQ44bWO2M=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5 h1:K/ojwjaivMZ45jt3dslKka1ciZvMrGbRuofN/PESL5o=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201129044102-91280e756de5/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201201090328-3a2078e373f0 h1:TUc11bYIC0asZE0EAA+6ZR93kuJHezVHXNYRcLMmzzU=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20201201090328-3a2078e373f0/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,7 @@
     },
     {
       "groupName": "Sourcegraph Docker images list",
-      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"],
-      "labels": ["automerge"]
+      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"]
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
It seems this does not work well yet with Sourcegraph's versioning<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
