### PR TITLE
renovate: only update images list by commit, automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,9 @@
     },
     {
       "groupName": "Sourcegraph Docker images list",
-      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"]
+      "packagePatterns": ["github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"],
+      "allowedVersions": "~=0.0.0",
+      "automerge": true
     },
     {
       "groupName": "Pulumi NPM packages",


### PR DESCRIPTION
This generates updates like this: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/189

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
