### PR TITLE
Wait longer for repos to be cloned

### DIFF
--- a/tests/integration/restricted/validate.json
+++ b/tests/integration/restricted/validate.json
@@ -19,7 +19,7 @@
   },
   "waitRepoCloned": {
     "repo": "github.com/sourcegraph-testing/repo-ssh-keys-test",
-    "maxTries": 6,
+    "maxTries": 10,
     "sleepBetweenTriesSeconds": 10
   },
   "searchQuery": "repo:^github.com/sourcegraph-testing/repo-ssh-keys-test$ gallery-director-drone-vacant-blizzard"


### PR DESCRIPTION
Tests are failing every now for `src validate` due to the repo https://buildkite.com/sourcegraph/deploy-sourcegraph/builds/6346#de9c4017-8673-4d91-bdbe-a758635d1cd4 not being cloned.

Given they pass every now and then, I assume this is just a matter of increasing the timeout.