### PR TITLE
Switch back to wrouesnel postgres exporter

### DIFF
--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -64,6 +64,7 @@ spec:
       - env:
         - name: DATA_SOURCE_NAME
           value: postgres://sg:@localhost:5432/?sslmode=disable
+        # Dax: Temporarily switch back to upstream postgres exporter        
         image: wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -64,9 +64,7 @@ spec:
       - env:
         - name: DATA_SOURCE_NAME
           value: postgres://sg:@localhost:5432/?sslmode=disable
-        - name: PG_EXPORTER_EXTEND_QUERY_PATH
-          value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:insiders@sha256:ac8ef017099276edef5df78fba63d633e68bd881fa56882074f4710e09ebe1ed
+        image: wrouesnel/postgres_exporter:v0.7.0@sha256:785c919627c06f540d515aac88b7966f352403f73e931e70dc2cbf783146a98b
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -18,7 +18,8 @@ trap 'bash -c "$CLEANUP"' EXIT
 
 CLUSTER_NAME_SUFFIX=$(echo ${BUILD_UUID} | head -c 8)
 CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
-CLUSTER_VERSION="1.15.12-gke.20"
+# get the STABLE channel version from GKE
+CLUSTER_VERSION=$(gcloud container get-server-config --zone us-central1-a -q 2>&1  | grep "defaultClusterVersion" | awk '{ print $2}')
 
 cd $(dirname "${BASH_SOURCE[0]}")
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -19,7 +19,7 @@ trap 'bash -c "$CLEANUP"' EXIT
 CLUSTER_NAME_SUFFIX=$(echo ${BUILD_UUID} | head -c 8)
 CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
 # get the STABLE channel version from GKE
-CLUSTER_VERSION=$(gcloud container get-server-config --zone us-central1-a -q 2>&1  | grep "defaultClusterVersion" | awk '{ print $2}')
+CLUSTER_VERSION=$(gcloud container get-server-config --zone us-central1-a -q 2>&1 | grep "defaultClusterVersion" | awk '{ print $2}')
 
 cd $(dirname "${BASH_SOURCE[0]}")
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -50,7 +50,8 @@ kubectl create serviceaccount -n ns-sourcegraph fake-user
 
 kubectl create rolebinding -n ns-sourcegraph fake-admin --clusterrole=admin --serviceaccount=ns-sourcegraph:fake-user
 
-kubectl create role -n ns-sourcegraph nonroot:unprivileged --verb=use --resource=podsecuritypolicies.extension --resource-name=nonroot-policy
+# Kubernetes < 1.16 change to '--resource=podsecuritypolicies.extensions'
+kubectl create role -n ns-sourcegraph nonroot:unprivileged --verb=use --resource=podsecuritypolicies.extensions --resource-name=nonroot-policy
 
 kubectl create rolebinding -n ns-sourcegraph fake-user:nonroot:unprivileged --role=nonroot:unprivileged --serviceaccount=ns-sourcegraph:fake-user
 


### PR DESCRIPTION
The codeintel DB cannot use the sourcegraph/postgres-exporter image today since it does not contain a migration table which our the sourcegraph/postgres-exporter queries for. 

This causes the exporter for code intel to continually emit errors

Found during https://github.com/sourcegraph/sourcegraph/pull/17131

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: We don't deploy Postgres exporter in docker-compose
* [x] All images have a valid tag and SHA256 sum 
