### PR TITLE
frontend: reorder fields to avoid conflicts and improve readability

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -27,7 +27,9 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - args:
+      - name: frontend
+        image: index.docker.io/sourcegraph/frontend:insiders@sha256:b69a210ec21ca10028937dd404467bc84b8da18b31772705199666bc70bc2647
+        args:
         - serve
         env:
         - name: PGDATABASE
@@ -67,7 +69,6 @@ spec:
           value: http://jaeger-query:16686
         - name: PROMETHEUS_URL
           value: http://prometheus:30090
-        image: index.docker.io/sourcegraph/frontend:insiders@sha256:b69a210ec21ca10028937dd404467bc84b8da18b31772705199666bc70bc2647
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -83,7 +84,6 @@ spec:
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5
-        name: frontend
         ports:
         - containerPort: 3080
           name: http
@@ -99,8 +99,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:b1397c275f9dabe6c073121125fd52e1a5989e3ae4897a0ffca86a4c2e36dc35
-        name: jaeger-agent
+      - name: jaeger-agent
+        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:b1397c275f9dabe6c073121125fd52e1a5989e3ae4897a0ffca86a4c2e36dc35
         env:
           - name: POD_NAME
             valueFrom:


### PR DESCRIPTION
<!-- description here -->

A few adjustments to alleviate a few pain points:

* Keep high-change fields away from each other to avoid conflicts (such as https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pull/737/files#diff-ec7bc0ca662869dbbc2ef4d656c14002c792de90b497619eacc312397347905d - custom env variables cause perpetual conflicts on image changes because the fields are next to each other
* Scrolling down 50 lines to find the name of a container feels less than ideal

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
