### PR TITLE
prometheus: add config for filtering cadvisor metrics by namespace

### DIFF
--- a/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -16,4 +16,4 @@ subjects:
 - kind: ServiceAccount
   name: cadvisor
   # value of namespace needs to match namespace value in base/cadvisor/cadvisor.ServiceAccount.yaml
-  namespace: default
+  namespace: ns-sourcegraph

--- a/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -15,5 +15,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cadvisor
-  # value of namespace needs to match namespace value in base/cadvisor/cadvisor.ServiceAccount.yaml
-  namespace: ns-sourcegraph

--- a/base/prometheus/README.md
+++ b/base/prometheus/README.md
@@ -65,7 +65,6 @@ metadata:
   labels:
     app: prometheus
   name: prometheus-node-port
-  namespace: ns-sourcegraph
 spec:
   externalTrafficPolicy: Cluster
   ports:

--- a/base/prometheus/README.md
+++ b/base/prometheus/README.md
@@ -65,7 +65,7 @@ metadata:
   labels:
     app: prometheus
   name: prometheus-node-port
-  namespace: default
+  namespace: ns-sourcegraph
 spec:
   externalTrafficPolicy: Cluster
   ports:

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -15,4 +15,4 @@ subjects:
 - kind: ServiceAccount
   name: prometheus
   # value of namespace needs to match namespace value in base/prometheus/prometheus.ServiceAccount.yaml
-  namespace: default
+  namespace: ns-sourcegraph

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -14,5 +14,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  # value of namespace needs to match namespace value in base/prometheus/prometheus.ServiceAccount.yaml
-  namespace: ns-sourcegraph

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -238,6 +238,16 @@ data:
         target_label: ns
 
       metric_relabel_configs:
+      # cAdvisor-specific customization. Drop container metrics exported by cAdvisor
+      # not in the same namespace as Sourcegraph.
+      # Uncomment this if you have problems with certain dashboards or cAdvisor itself
+      # picking up non-Sourcegraph services. Ensure all Sourcegraph services are running
+      # within the Sourcegraph namespace you have defined.
+      # The regex must keep matches on '^$' (empty string) to ensure other metrics do not
+      # get dropped.
+      # - source_labels: [container_label_io_kubernetes_pod_namespace]
+      #   regex: ^$|ns-sourcegraph # ensure this matches with namespace declarations
+      #   action: keep
       # cAdvisor-specific customization. We want container metrics to be named after their container name label.
       # Note that 'io.kubernetes.container.name' and 'io.kubernetes.pod.name' must be provided in cAdvisor
       # '--whitelisted_container_labels' (see cadvisor.DaemonSet.yaml)


### PR DESCRIPTION
Simpler take on https://github.com/sourcegraph/deploy-sourcegraph/pull/1578 - leaving that open to reassess options. See that PR + discussion for more details. Part of work that closes https://github.com/sourcegraph/sourcegraph/issues/17069.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
