### PR TITLE
release: sourcegraph@3.24.1

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.24.0@sha256:7c85e692ea50b5b73db9163c9eb71d547710dd8a5f35e52080368d44111ad5bc
+        image: index.docker.io/sourcegraph/cadvisor:3.24.1@sha256:94374a265cc49fea4d32416b86c7ec3e40dc19dcb9d9196aa7d267b271fd7bad
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/codeintel-db:3.24.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.24.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.24.0@sha256:0cd42a1922384266b0bf900443c9b32f56ca1c67dc0ce6e655cf0d4e2599ef7d
+        image: index.docker.io/sourcegraph/frontend:3.24.1@sha256:34a642351c054502a1e60c053ffaa7951c199bfb0fe6b1ff276b0b25588685e2
         args:
         - serve
         env:
@@ -100,7 +100,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+        image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:3.24.0@sha256:ee5d7156b281812b60e176c41f944692be61f053a1dfd545ecf164f5e58709ff
+        image: index.docker.io/sourcegraph/github-proxy:3.24.1@sha256:2b984724ecd31f02ffeb3b5b2539ba9008032a9df29b7a27e499a3fc80f97762
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:3.24.0@sha256:aaffd21d18b791c73032e916c2bf69ecf51a3a97608ab748408889d5b192dfac
+        image: index.docker.io/sourcegraph/gitserver:3.24.1@sha256:c582534891428ba7c7960b479b867e2aa418917ddbed776eab6f6ca0a37b733d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -53,7 +53,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+        image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:3.24.0@sha256:32b35cd39f13149ea2e7ca192c5ee97400b06aa6f7b5664b4cd79797d9d40417
+      - image: index.docker.io/sourcegraph/grafana:3.24.1@sha256:3b85e816a8f1b9fff587b759605d6340964e4a89eb56fd6784f7f1f768797072
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:3.24.0@sha256:76d7e8a7453caed03412064d2f8e40dd49b9df958edd846e5a91c514b840803e
+        image: index.docker.io/sourcegraph/indexed-searcher:3.24.1@sha256:76d7e8a7453caed03412064d2f8e40dd49b9df958edd846e5a91c514b840803e
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -48,7 +48,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:3.24.0@sha256:89fa7d5eac6f9f3e8893a482650dffcea4d22be993328427679af7e3ddd08e10
+        image: index.docker.io/sourcegraph/search-indexer:3.24.1@sha256:89fa7d5eac6f9f3e8893a482650dffcea4d22be993328427679af7e3ddd08e10
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.24.0@sha256:64777c4affa429cbed6237f5055694dc1071155e350cfa4d10c35d8078d4da32
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.24.1@sha256:7015e25e08cbb169828c8e1bc995d967e81d3706eea79f0fc43280e126a6e576
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.24.0@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.24.1@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         name: minio

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.24.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.24.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:3.24.0@sha256:793ddb0ba309ee1b52e116e6eb7498f0ca4e4b2ee885673ee7cf255c15fdadeb
+        image: sourcegraph/postgres_exporter:3.24.1@sha256:494af07168d2a9dbc153a80b82a9f3b4254aaaf20301a834a7b73c5bfd0ab030
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.24.0@sha256:7bb843018e52144a6cdeaa88c888df45aea6ed3b558b6cd991a2b3884e0fe9b1
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.24.1@sha256:eb1edce00bfe44a0b48305c5fa598f834aa712de3c744c041dda81103d46b4e0
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:3.24.0@sha256:3ea1f8646f9b29143436dd1f4932ed106647388247f2ba7ad9956e97c3c05312
+      - image: index.docker.io/sourcegraph/prometheus:3.24.1@sha256:57e1b06908ef52cc0ba11d5f79894c01b65c609fd815aa8a93f91102b56a29ce
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:3.24.0@sha256:30b3c14098447148270bd0ff4552a0a7a76c07e6f72fc809a829d6d54426544a
+        image: index.docker.io/sourcegraph/query-runner:3.24.1@sha256:90db97ccd53b16fd70c94891a1e36f3d03583442165fa7579516331c13131e93
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:3.24.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.24.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:3.24.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.24.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:3.24.0@sha256:4b4303984ebff22af65d848108a334d1f2de7fafae7ccb39a3f24c2c3b6185d2
+      - image: index.docker.io/sourcegraph/repo-updater:3.24.1@sha256:4b3efefff54882d2ac10d77e444caed2e3f51fcd7e11e841e4025b36e96b47d5
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -52,7 +52,7 @@ spec:
           requests:
             cpu: "1"
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.24.0@sha256:3f315c62a9081e57e95571085bbc5f3e25a05edfe1b63d275f22d11b5db37e73
+        image: index.docker.io/sourcegraph/searcher:3.24.1@sha256:a2f20fc7fab1dc594c1d89c590151e571eb86bb727a320a4a613f1139572b958
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -62,7 +62,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.24.0@sha256:589a6a025a9c94ee8165ed43977e7e3e54c9631414c53a35d4927e5ad7774bdd
+        image: index.docker.io/sourcegraph/symbols:3.24.1@sha256:59ea001223edff4a2f85f44116c6bc236fdbd1db3d3b73553ea04eb5b9bd4db0
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -68,7 +68,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.1@sha256:eb3ecda1149ab8ff6142e53f825f7bca4cfd2102ee850bc79e6f95ca96187a7d
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.24.0@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.24.1@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.24.1 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.24.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/17770)