### PR TITLE
add limits for ephemeral storage

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -92,9 +92,11 @@ spec:
         resources:
           limits:
             cpu: "2"
+            ephemeral-storage: "8Gi"
             memory: 4G
           requests:
             cpu: "2"
+            ephemeral-storage: "4Gi"
             memory: 2G
         volumeMounts:
         - mountPath: /mnt/cache

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -55,9 +55,11 @@ spec:
         resources:
           limits:
             cpu: "2"
+            ephemeral-storage: "8Gi"
             memory: 2G
           requests:
             cpu: 500m
+            ephemeral-storage: "4Gi"
             memory: 500M
         volumeMounts:
         - mountPath: /mnt/cache

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -61,9 +61,11 @@ spec:
         resources:
           limits:
             cpu: "2"
+            ephemeral-storage: "8Gi"
             memory: 2G
           requests:
             cpu: 500m
+            ephemeral-storage: "4Gi"
             memory: 500M
         volumeMounts:
         - mountPath: /mnt/cache


### PR DESCRIPTION
These initial figures are speculative at best, and customers would need to set these themselves in my cases I imagine depending on deployment size. 

These change also doesn't modify anything in the configure directory. 

fixes https://github.com/sourcegraph/sourcegraph/issues/9604

