### PR TITLE
codeinsights-db: remove liveness/readiness probes

### DIFF
--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -31,15 +31,6 @@ spec:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password
         terminationMessagePolicy: FallbackToLogsOnError
-        readinessProbe:
-          exec:
-            command:
-              - /ready.sh
-        livenessProbe:
-          initialDelaySeconds: 15
-          exec:
-            command:
-              - /liveness.sh
         ports:
         - containerPort: 5432
           name: timescaledb


### PR DESCRIPTION
These scripts do not exist in the base image (I based the YAML on codeinsights-db,
where it turns out bakes these scripts into the postgres image we ship.)

I will need to revisit adding these, for now removing so it does not produce broken
deployments.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>