### PR TITLE
frontend: configure codeinsights DB env var

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -42,6 +42,8 @@ spec:
           value: disable
         - name: PGUSER
           value: sg
+        - name: CODEINSIGHTS_PGDATASOURCE
+          value: postgres://postgres:password@codeinsights-db:5432/postgres
         - name: CODEINTEL_PGDATABASE
           value: sg
         - name: CODEINTEL_PGHOST


### PR DESCRIPTION
I missed this by accident, and it prevented the frontend from starting
up (I could have set `DISABLE_CODEINSIGHTS=true` to escape, though):

```
$ kubectl -n prod logs sourcegraph-frontend-687546fb9-62nrn frontend
failed to initialize insights: Failed to connect to codeinsights database: DB not available: failed to connect to `host=127.0.0.1 user=root database=sg`: server error (FATAL: password authentication failed for user "root" (SQLSTATE 28P01))
```

Filed issue to make frontend not block on codeinsights in general: https://github.com/sourcegraph/sourcegraph/issues/18388

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>