### PR TITLE
release: sourcegraph@3.25.0

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:insiders@sha256:fd0cc4502ee63e7bda7eefac1b12b33c3708efc6764f1a94622b24938a7ae610
+        image: index.docker.io/sourcegraph/cadvisor:3.25.0@sha256:0f5205608d3394a0b8893288dab0b894d800b6a8976dd4b9d64b627cb715207c
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
+        image: index.docker.io/sourcegraph/codeinsights-db:3.25.0@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.25.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:insiders@sha256:8aa7af3381cc8f7896a38d50dc86523896bef1a551c721f557747893565cd17a
+        image: index.docker.io/sourcegraph/frontend:3.25.0@sha256:86b8b0c82b320d9315ceb9d1d65bc7af88824bd2f5713b922eb11751a46c3e19
         args:
         - serve
         env:
@@ -104,7 +104,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:c04d00a8f13556fceddffb1e4f132dcc311936727c468a8c1d407ce6e7bb01ca
+        image: index.docker.io/sourcegraph/github-proxy:3.25.0@sha256:436baeab0674509afba896217d263ca4c6c8e9ab22fc2aae3feef5368c96e405
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:3536a2ada0bd9cc5e099fd8851b819592d566c5eb85c102494e73d1aa914c506
+        image: index.docker.io/sourcegraph/gitserver:3.25.0@sha256:24f51ac71469ca03c4b275e2ed02a1275f4791f8e96abe0ad7c462e187df291d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:insiders@sha256:2cded9e6b3893743ecf28f9474ebb9b22b3b576c163238bb31c4de922d7cd522
+        image: index.docker.io/sourcegraph/grafana:3.25.0@sha256:b757de0fa8f8554d0c9f22f11ae8495aed58b2a05cde01d5a12b28b36993bb8c
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:0cb04c4b0cb0e225907f14d25a8f83912a17c09c57c2c1cc689436f7538aaa3b
+        image: index.docker.io/sourcegraph/indexed-searcher:3.25.0@sha256:0cb04c4b0cb0e225907f14d25a8f83912a17c09c57c2c1cc689436f7538aaa3b
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:1099fb80f0dc43ee18339e661aefa7cb1372df5f8901cf7ce3bed28d0dd251fd
+        image: index.docker.io/sourcegraph/search-indexer:3.25.0@sha256:1099fb80f0dc43ee18339e661aefa7cb1372df5f8901cf7ce3bed28d0dd251fd
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:cbc9e3be25401cc4c8bacef3d720a26f17d54034eeceae05346974f8eb0a8577
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.25.0@sha256:935943687e42927300c85401740a0fbeb893567911efc8c9f31342debda57564
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:insiders@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.25.0@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.25.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:insiders@sha256:37c01d94934a15baecbf40042da0799f7761f28d6084c0ceb7e038224fc4d613
+        image: sourcegraph/postgres_exporter:3.25.0@sha256:4e58f9b2caa4a393afe0d524305524ca2120d07e4aa0c7561eee7acf57d9193c
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:9800c096f5f85e87eb59e021ad77fd4dafdd68c0186a24586aba0d7785cbb7a7
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.25.0@sha256:8393aed4e6737b86d2febfc5f855e1d0f71aeaa5de77a2291fc5858c1525f61e
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:insiders@sha256:403984770ca4d6125eff09b681049600cac0ba420b2f108eb88b72cdfc1ff3c3
+        image: index.docker.io/sourcegraph/prometheus:3.25.0@sha256:a78c1d174d588d22882eb0d109a9cb21c53215f2595a68d829c10f791dec611b
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:insiders@sha256:1d20efa742db97d3c249e30d0039c0697afce3a4ea3c86cc24b4df535e2a9f40
+        image: index.docker.io/sourcegraph/query-runner:3.25.0@sha256:f71268fd569394a4573e5fae31a5725de25c4aaeef5c6435808723e38eeb0800
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.25.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.25.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:447e7f6af2cc36d06fb6ab352a5285cafce8681dc884d807f3316f79e678b3c1
+        image: index.docker.io/sourcegraph/repo-updater:3.25.0@sha256:3b966baf4c8b65d24e26ae9e3df4d12daca58f372d5f80c83a41af10e277715a
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -53,7 +53,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:insiders@sha256:4e16b3b279f9fcffdba04460e251bde2625786e87ba962e214b3ba2392fe18f0
+        image: index.docker.io/sourcegraph/searcher:3.25.0@sha256:8b33c98af01bab302602cbd907772ecc5615d875346cccaf9d35079c4502575f
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:insiders@sha256:847d382f87a7c8525978e4303e96c6642b413b78a733c1ed7db6f4d0736e6eeb
+        image: index.docker.io/sourcegraph/symbols:3.25.0@sha256:c8b5a48117851733649b2ad137877ae06823f3e9971a824ad8775207e4871a43
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:8c59257d0ad77fcb5f50ae9229f292d8b496b0e0be51cd2ad657ffe4dd6b5f65
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.0@sha256:7322afccd1925ee4c68fc7b77629041975d3108f3bf2b8c13572406014978c24
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.25.0@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.25.0 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.25.0)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/17727)