### PR TITLE
codeinsights-db: correct data volume path

### DIFF
--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -30,6 +30,8 @@ spec:
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 5432

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             cpu: "4"
             memory: 2Gi
         volumeMounts:
-        - mountPath: /data
+        - mountPath: /var/lib/postgresql/data/
           name: disk
         - mountPath: /conf
           name: timescaledb-conf


### PR DESCRIPTION
I failed to verify `/data` was the correct path (it is for our other Postgres images, but not for this TimescaleDB image), which means codeinsights-db data is not being retained currently. I noticed this because the DB was lost on sourcegraph.com (chart looks empty.)

The good news is that I am actively working on building historical data for insights, so this data loss doesn't really matter - it'll all be rebuilt later.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18704

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/268
* [x] All images have a valid tag and SHA256 sum
