### PR TITLE
release: sourcegraph@3.25.2

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.25.1@sha256:5189f5e4d67ebe6ec45ecfa2810631927ff067c95d9fc22f22d29ca1ce44a8ef
+        image: index.docker.io/sourcegraph/cadvisor:3.25.2@sha256:9e060f685d9b55f560912ff7be85a77f24366fe0cc646cb8069443ce369b65e3
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:3.25.1@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
+        image: index.docker.io/sourcegraph/codeinsights-db:3.25.2@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.25.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.25.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.25.1@sha256:50fa4888c276eb4727ce95c82087adec625ce7ca9bff55f48e64e9e22906af3c
+        image: index.docker.io/sourcegraph/frontend:3.25.2@sha256:d22244aad7dda2328d2f18980bc925b7f4763d198a3fa584766ab00c11082b8a
         args:
         - serve
         env:
@@ -104,7 +104,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.25.1@sha256:25c839ffdef14b0951d2dfffcb8aafb8012e520d79bccba16de7f915d4ed416d
+        image: index.docker.io/sourcegraph/github-proxy:3.25.2@sha256:09ac53c032b81f36eb5a5751212ec437990e3ebe0bfd5cf37c83988d4d916747
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.25.1@sha256:167f94a77e7b5622e94c557dd31574d653e2beabf1ce9a1715eea7ce3a4ec5a7
+        image: index.docker.io/sourcegraph/gitserver:3.25.2@sha256:a43a8439e6bf3c419a1f9d7d4c6cd51fb7cddc53ee9c68455e5ec5e94d20b9a6
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.25.1@sha256:e3b858a7d00c4f72bbc2d95cd0684a0bc769bf0945686d8801ae6b2b10ca1993
+        image: index.docker.io/sourcegraph/grafana:3.25.2@sha256:e5a917e3a96f5557ecbfca7b3236ef2a138e18b0d467db3ba0f7d4175530e9ff
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.25.1@sha256:0cb04c4b0cb0e225907f14d25a8f83912a17c09c57c2c1cc689436f7538aaa3b
+        image: index.docker.io/sourcegraph/indexed-searcher:3.25.2@sha256:0cb04c4b0cb0e225907f14d25a8f83912a17c09c57c2c1cc689436f7538aaa3b
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.25.1@sha256:1099fb80f0dc43ee18339e661aefa7cb1372df5f8901cf7ce3bed28d0dd251fd
+        image: index.docker.io/sourcegraph/search-indexer:3.25.2@sha256:1099fb80f0dc43ee18339e661aefa7cb1372df5f8901cf7ce3bed28d0dd251fd
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.25.1@sha256:b41787f787389772ff59caadb24babc0b920d99c602bd54341cdceb3643f8fc9
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.25.2@sha256:7509cdb033e7fef27fc590bd4aca45bdbb9ddce6f1b96ccef3e0e8a8a12c863d
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.25.1@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.25.2@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.25.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.25.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:3.25.1@sha256:ccbfce8a738f1d4a28640fc62f20f5da65379393791a5a232c03cf0acc4f519b
+        image: sourcegraph/postgres_exporter:3.25.2@sha256:b2a02a91a31aa9e44f82f10152ea8d7b654e5aa2df8cafada99d27697c815c2f
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.25.1@sha256:834f1248d58c6228c9ef4788f67caeb9e7caab97f2f167a49102faf074af6a7d
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.25.2@sha256:7b78ad1ccd080f7a4fb67d494315f2e84376e66f4a2c6bbdb2dad01e2ba7924d
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.25.1@sha256:b738dc71624904d00a58937a84487f255fcc7efc735459fa0099d1c965be01af
+        image: index.docker.io/sourcegraph/prometheus:3.25.2@sha256:b8a4bc5bf516d5bc9933c6614c64c38371f29a2f55f0d091602f550b4b3a0ee5
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.25.1@sha256:7b3ac73179557851d990058721c5f8dd5a01e7acfc2e4d8893c02a771de0398d
+        image: index.docker.io/sourcegraph/query-runner:3.25.2@sha256:b1e8e1532d447662f0e67460dfc145b66f8e3172bcaa12815b8e113e8d1459ab
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.25.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.25.2@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.25.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.25.2@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.25.1@sha256:7ee4c5c28c21e3d73d14a4c0a7dbff6f2ee585f1821586291ad42b89bd3a3c68
+        image: index.docker.io/sourcegraph/repo-updater:3.25.2@sha256:82e37e82a2e24cec4da5582f2bfa3863e2e150a240fd63579c3ef2b5fb30d42f
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -53,7 +53,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.25.1@sha256:f7d4b5f4dda1fc662bc34c4dd15b61392f71af91ed8a1276c2e72e2001be7dc7
+        image: index.docker.io/sourcegraph/searcher:3.25.2@sha256:f2678f07f4af5560567bf44bb557f919b6a0f66074682e187e5c43b120678c9a
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.25.1@sha256:36217e63eb22f4b9c6aa87c0a640382830d8608ea22eda24b436fe744b8a77af
+        image: index.docker.io/sourcegraph/symbols:3.25.2@sha256:617ea086b9d19564d24b0ac599290c12a2b74702d9f9df3ac45f4baf97eef6b3
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.25.1@sha256:589370a08643abc7029b27196e798026a184709754646c4556a7c3d7e2d85585
+        image: index.docker.io/sourcegraph/jaeger-agent:3.25.2@sha256:48711e706cfdb85f99be639e7d8c09bca80d7c5d970a5f951b505ae21312f449
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.25.1@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.25.2@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.25.2 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.25.2)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/18737)