### PR TITLE
update minikube overlay with cluster role bindings

### DIFF
--- a/overlays/minikube/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/overlays/minikube/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cadvisor
+subjects:
+  - kind: ServiceAccount
+    name: cadvisor
+    namespace: ns-sourcegraph

--- a/overlays/minikube/kustomization.yaml
+++ b/overlays/minikube/kustomization.yaml
@@ -5,6 +5,9 @@ bases:
   - ../bases/deployments
   - ../bases/rbac-roles
   - ../bases/pvcs
+patchesStrategicMerge:
+  - prometheus/prometheus.ClusterRoleBinding.yaml
+  - cadvisor/cadvisor.ClusterRoleBinding.yaml
 patchesJson6902:
   - target:
       kind: Deployment

--- a/overlays/minikube/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/overlays/minikube/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: ns-sourcegraph


### PR DESCRIPTION
fixes:

```
Error from server (Invalid): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"cadvisor\",\"app.kubernetes.io/component\":\"cadvisor\",\"category\":\"rbac\",\"deploy\":\"sourcegraph\",\"sourcegraph-resource-requires\":\"cluster-admin\"},\"name\":\"cadvisor\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"cadvisor\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"cadvisor\"}]}\n"}},"subjects":[{"kind":"ServiceAccount","name":"cadvisor"}]}
to:
Resource: "rbac.authorization.k8s.io/v1, Resource=clusterrolebindings", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"
Name: "cadvisor", Namespace: ""
for: "base/cadvisor/cadvisor.ClusterRoleBinding.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "cadvisor" is invalid: subjects[0].namespace: Required value
Error from server (Invalid): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"prometheus\",\"category\":\"rbac\",\"deploy\":\"sourcegraph\",\"sourcegraph-resource-requires\":\"cluster-admin\"},\"name\":\"prometheus\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"prometheus\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"prometheus\"}]}\n"}},"subjects":[{"kind":"ServiceAccount","name":"prometheus"}]}
to:
Resource: "rbac.authorization.k8s.io/v1, Resource=clusterrolebindings", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"
Name: "prometheus", Namespace: ""
for: "base/prometheus/prometheus.ClusterRoleBinding.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "prometheus" is invalid: subjects[0].namespace: Required value
```