### PR TITLE
Remove status triggers for automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-# based on https://github.com/pascalgn/automerge-action/tree/v0.9.0#usage
+# based on https://github.com/pascalgn/automerge-action/tree/v0.13.0#usage
 name: Automerge
 on:
   pull_request:
@@ -17,14 +17,16 @@ on:
   check_suite:
     types:
       - completed
-  status: {}
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: pascalgn/automerge-action@v0.12.0
+        uses: pascalgn/automerge-action@v0.13.0
         env:
           # Allows this merge to trigger other actions
           GITHUB_TOKEN: "${{ secrets.DISPATCH_PERSONAL_ACCESS_TOKEN }}"
           MERGE_METHOD: squash
+          MERGE_RETRIES: 60
+          MERGE_LABELS: automerge # Set by renovate bot or users


### PR DESCRIPTION
This prevents this to constantly trigger as `status` triggers too frequntly.
