### PR TITLE
release: sourcegraph@3.26.0

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:insiders@sha256:dd33b24e6afdcd91478dc08c72cdbc72629597092c70e85459d262b302e9fa19
+        image: index.docker.io/sourcegraph/cadvisor:3.26.0@sha256:f72a029de48477071d03cece553a2769bccc8200fe33b1d8db82ea8cd98d6242
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.26.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:insiders@sha256:c28ae1f6bb3db9514b645eb628da817f61f1cb6930639298dd63d59907e5134f
+        image: index.docker.io/sourcegraph/frontend:3.26.0@sha256:236ac617dbc9f50d371734d4a631538d641751af2ff733488bec9acc83972cc9
         args:
         - serve
         env:
@@ -104,7 +104,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:a4048e50b887db88ec571a7b3511aca48660814c7146dc9a7168476578afc286
+        image: index.docker.io/sourcegraph/github-proxy:3.26.0@sha256:0d18a82956838d6e3012943f6e70483255074664edd4400f09a6c58af9292ba7
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:c461f3a1c98158285fc531d16ee3f5a33d7c25ba89542c5c1d463e1adc69a7b8
+        image: index.docker.io/sourcegraph/gitserver:3.26.0@sha256:cdc87172566506a51d8991f76db96c7ae409bfd42f0c01b95c965ee51c3f7e18
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:insiders@sha256:b7b9b588b3ecffa8f71a9c28ac5a48b282d92adacf869c5aaf2e1681a97e7144
+        image: index.docker.io/sourcegraph/grafana:3.26.0@sha256:4062c7cf032616b6212ebdc77fe8638ceb4a8c4babede4756949dfb5f67ba19d
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:1e5040bd81184bf4276ceb5dda9614d73835253c2ad063ca9f5a56602b6beca7
+        image: index.docker.io/sourcegraph/indexed-searcher:3.26.0@sha256:7cd80afcb50f015d6a9de5fb98ad08d3c5e6225f6e32f6f4ee6d4d81634d56aa
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:fbcf55d45bed9ea4ea118e8bf858a87914395937da0833daa83b9386c7aa88e5
+        image: index.docker.io/sourcegraph/search-indexer:3.26.0@sha256:42081daa7d205bb610d3cf2d561e2e9899459aeded363e4efec13026ad264c5c
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:beb14a99ae51f669619a59b3e6700f83c0b8737ccc6b5e0ba64dcfdf2efc9886
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.26.0@sha256:c2f87037716065f0344109af44a4681a2bee65ea501bc46487d991c934ef3c4b
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:insiders@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.26.0@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.26.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:insiders@sha256:37c01d94934a15baecbf40042da0799f7761f28d6084c0ceb7e038224fc4d613
+        image: sourcegraph/postgres_exporter:3.26.0@sha256:e3affff0d54b696db17fb2dceeb1f46f49a2c06a308d05a14e5ebc9e05a17a37
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:074b2a80e75fddc1ac1776acbfcb0bad24eda7460e53448a810f9319a79ed2aa
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.26.0@sha256:26ecbdf158716c1e6b53801acc50b270ab1b962cfbaec3e891f2b20054a986bf
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:insiders@sha256:741ad8833972a07a194f66633c14a980aa66a7b1a8998ac01b90717ac4986e04
+        image: index.docker.io/sourcegraph/prometheus:3.26.0@sha256:66387d2a32c556c89e2a01acf6a16717462f098ccce8fd99d9ad58feeea569ca
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:insiders@sha256:c4468c1d8402d9d5258079c6f24c247c58d6c49e3f0b3136fefc5835fe6f5a83
+        image: index.docker.io/sourcegraph/query-runner:3.26.0@sha256:ab4fbeafdddde407ade58b4b825d5a46eaae5734600522199fb626b6881e7a66
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.26.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.26.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:5c0363e191fae1fb378b1395149006170c7f99c159921ff2532bf0fddfc24fcd
+        image: index.docker.io/sourcegraph/repo-updater:3.26.0@sha256:d76063e4571e963ed68c7423ccf6fe7ccaf4a45a60717cf89d873a6b14a64183
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -53,7 +53,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:insiders@sha256:3fa1f2e015b7d460d5d0507b5ea72949772c62c902035d391a641a558c828d99
+        image: index.docker.io/sourcegraph/searcher:3.26.0@sha256:0ad1fd53ff4bb0f6a0f2ecfe9ccf560ff6e3e5a84282c8e9a785e80e81d2cd01
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:insiders@sha256:88acaa9c3c988e12a0297b928f749c7b3f499133ced6569eb8ab191f6bf1e112
+        image: index.docker.io/sourcegraph/symbols:3.26.0@sha256:d9c6dc767c109f14f266ab0673a6dcc1da60dea72c0d3529f0c1576ebd68d7c5
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:702048d37fcc2e084c7178ba221f691ff706c18a89c6c14076c5305b17ae4539
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.0@sha256:06924936f9eccd82832293f4783ea7940d9b82759cfcc322c1f51d0f216ef4e8
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.26.0@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.26.0 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.26.0)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/18640)