### PR TITLE
remove 1.15

### DIFF
--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -21,7 +21,7 @@ func TestFreshDeployment(t *testing.T) {
 	noCleanup := os.Getenv("NOCLEANUP") == "true"
 
 	// Validate on various kubernetes versions
-	for _, k8sVersion := range []string{"1.15", "1.16", "1.17", "1.18"} {
+	for _, k8sVersion := range []string{"1.16", "1.17", "1.18"} {
 		k8sVersion := k8sVersion
 		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {
 			config, err := commonConfig()


### PR DESCRIPTION
v1.15 is no longer available

https://cloud.google.com/kubernetes-engine/docs/release-notes#March_29_2021
