### PR TITLE
Increase frontend and precise-code-intel-worker replicas

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: sourcegraph-frontend
 spec:
   minReadySeconds: 10
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: precise-code-intel-worker
 spec:
   minReadySeconds: 10
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:


### PR DESCRIPTION
By default we deploy a single replica but these services support
scaling horizontally and can be HA by running 2 replicas.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [x] All images have a valid tag and SHA256 sum