### PR TITLE
release: sourcegraph@3.26.2

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.26.1@sha256:564c2fa067e46833c9fc1661f03e3996ad2c5da874c7e32030125abc53990b9e
+        image: index.docker.io/sourcegraph/cadvisor:3.26.2@sha256:4fb0367e7bf05765cde10ffb26f19a4d0fe9ab6be60272cfe77890e5cb1ef310
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:3.26.1@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
+        image: index.docker.io/sourcegraph/codeinsights-db:3.26.2@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.26.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.26.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.26.1@sha256:77e5da2ba6cc19a90a8b6e1d99b72c493fcbb03f08c50ed07de20454dbf1d456
+        image: index.docker.io/sourcegraph/frontend:3.26.2@sha256:71862016500d1c1c4718e1aad98a8e3acb6651a7904ad085603dd0dccbe7cc31
         args:
         - serve
         env:
@@ -104,7 +104,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.26.1@sha256:6cbe12d9e82f056b6845c93aa67b775143d719d913bd8725d9ca92aad26a031c
+        image: index.docker.io/sourcegraph/github-proxy:3.26.2@sha256:999418d889d8e67ceb12f39ce629bd98ad9414c2d954fdbd834a494f39b9ffed
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.26.1@sha256:a27ab3c9fbc5b979d916c3d312f1ecbe4f6375314eb28845ddf164473e069f61
+        image: index.docker.io/sourcegraph/gitserver:3.26.2@sha256:6312788ae61183e534eb20319ba61c47776f718086c969e4c491b0f62b554f1a
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.26.1@sha256:6ef285630fec074ea21250ad1b50bc7f615c93c3994ac98a381b79b536cc4de6
+        image: index.docker.io/sourcegraph/grafana:3.26.2@sha256:6dc845eb2d51642ba46c51ef1acffec8631582d96a6031dd2e8421898414c142
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.26.1@sha256:7cd80afcb50f015d6a9de5fb98ad08d3c5e6225f6e32f6f4ee6d4d81634d56aa
+        image: index.docker.io/sourcegraph/indexed-searcher:3.26.2@sha256:7cd80afcb50f015d6a9de5fb98ad08d3c5e6225f6e32f6f4ee6d4d81634d56aa
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.26.1@sha256:42081daa7d205bb610d3cf2d561e2e9899459aeded363e4efec13026ad264c5c
+        image: index.docker.io/sourcegraph/search-indexer:3.26.2@sha256:42081daa7d205bb610d3cf2d561e2e9899459aeded363e4efec13026ad264c5c
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.26.1@sha256:f899dca0640cd7fb78032d83bb75c3097d4d04f62b00d8902a1a31a456aebb43
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.26.2@sha256:b9ebec34ccbfbc09aed9643d622b972f65048e7e4c54e7f1afe0b114b934c954
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.26.1@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.26.2@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:3.26.1@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.26.2@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:3.26.1@sha256:3dfcebb3626dcd57f6f9b054bc63c6c60d2793c7a928177e0a887ee77f84d680
+        image: sourcegraph/postgres_exporter:3.26.2@sha256:62a4bd45416be7ffd15617369a4f7fb950d57b352ae2dfa111ddab62e084c345
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.26.1@sha256:907be1eef0a2caaf1bccd04356e72d1648a8fe9119167698ed31fbafc8b6f19e
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.26.2@sha256:2e73f3d0b1a04cd59cf7a5302804a2ad0170a3723dc9c9673b937020585debf6
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.26.1@sha256:fb573ef8d1c52b0c9a2d0b2d190b976832c68ab8dbfe3aea62ef1580c9e802c2
+        image: index.docker.io/sourcegraph/prometheus:3.26.2@sha256:fffa6f9b1f6c5b8fe186809a1a9e7f239bd1af3a1312ea5091f226096cd2497a
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.26.1@sha256:039fa11910efe0fd233d446c2726c6dc4e6ce9b60ac2b54156e0678ea608014e
+        image: index.docker.io/sourcegraph/query-runner:3.26.2@sha256:df8850bb1cf036957fc222f315cea7532c056a33354588572bcec7b292865e41
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.26.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.26.2@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.26.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.26.2@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.26.1@sha256:4854356eeb511dc5049b444ce90f65fd94192dbae2d85a3022718ecea613a567
+        image: index.docker.io/sourcegraph/repo-updater:3.26.2@sha256:ebb72992bb858b6320b443f1bf27267d381f63d7381b02421a672329193ed1f2
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -53,7 +53,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.26.1@sha256:0dada6843e49c2e874fcf4a8e6bff0008f7975e5aa32e1c302278b93401cfcb4
+        image: index.docker.io/sourcegraph/searcher:3.26.2@sha256:158578f01c415b523dbca698ad05b1221919f6c5a6943f9eebe1b4184d789c95
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.26.1@sha256:b509ae67610d1f6d3efcf9f3c7a01c7b5418ff2c5a45b427f84c06c5571e8773
+        image: index.docker.io/sourcegraph/symbols:3.26.2@sha256:68140abc70c79122fc224a575333d0d3990a1e8ace9a5d9fab0fbc7c40c363ae
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.26.1@sha256:3515c6bddd41adcb12e5334e5a8b10d236a20f78e68d8eb6f40919a93992b3e4
+        image: index.docker.io/sourcegraph/jaeger-agent:3.26.2@sha256:b21797580f08958b1ddec7d4faae444994d0e34248841637f86e76cf73b4ebcc
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.26.1@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.26.2@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -21,7 +21,7 @@ func TestFreshDeployment(t *testing.T) {
 	noCleanup := os.Getenv("NOCLEANUP") == "true"
 
 	// Validate on various kubernetes versions
-	for _, k8sVersion := range []string{"1.15", "1.16", "1.17", "1.18"} {
+	for _, k8sVersion := range []string{"1.16", "1.17", "1.18"} {
 		k8sVersion := k8sVersion
 		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {
 			config, err := commonConfig()


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.26.2 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.26.2)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/19775)