### PR TITLE
use new liveness and readiness endpoint

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -75,14 +75,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: http
+            port: health-check
             scheme: HTTP
           initialDelaySeconds: 300
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: http
+            path: /ready
+            port: health-check
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5
@@ -91,6 +91,8 @@ spec:
           name: http
         - containerPort: 3090
           name: http-internal
+        - containerPort: 6060
+          name: health-check
         resources:
           limits:
             cpu: "2"

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -75,14 +75,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: health-check
+            port: debug
             scheme: HTTP
           initialDelaySeconds: 300
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /ready
-            port: health-check
+            port: debug
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5
@@ -92,7 +92,7 @@ spec:
         - containerPort: 3090
           name: http-internal
         - containerPort: 6060
-          name: health-check
+          name: debug
         resources:
           limits:
             cpu: "2"

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -40,14 +40,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: http
+            port: debug
             scheme: HTTP
           initialDelaySeconds: 60
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: http
+            path: /ready
+            port: debug
             scheme: HTTP
           periodSeconds: 5
           timeoutSeconds: 5

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -41,7 +41,15 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: http
+            port: debug
+            scheme: HTTP
+          periodSeconds: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: debug
             scheme: HTTP
           periodSeconds: 1
           timeoutSeconds: 5


### PR DESCRIPTION
uses different endpoint for liveness and readiness to avoid crashing during large migrations

related: https://github.com/sourcegraph/sourcegraph/issues/19757
