### PR TITLE
release: sourcegraph@3.27.1

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.27.0@sha256:cfde28509acfe5e1a801e7a187a65ad2dc83a12ea9cf73402b22a365383f64a8
+        image: index.docker.io/sourcegraph/cadvisor:3.27.1@sha256:695145832e9cb9fcdd286ceaf542454565135760cb59798e6379b2315708d79d
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.27.0@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
+        image: index.docker.io/sourcegraph/codeintel-db:3.27.1@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.27.0@sha256:b7f042ed31049cd99399b7a8b8e1bfa0bb36fd4c3d5a4622181d74e8e3a9e94c
+        image: index.docker.io/sourcegraph/frontend:3.27.1@sha256:de14a364d6022bd3a96c3cb62a210fee2e5df55344e89544c2e8396869dff653
         args:
         - serve
         env:
@@ -106,7 +106,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.27.0@sha256:4c49354d0b6b4e6e2160b873aaff8cad683fe72e83d60e4c0d584695b209890a
+        image: index.docker.io/sourcegraph/github-proxy:3.27.1@sha256:6e6f77177bca3a8c8539f340e43892fe92f09198054709b6a40f43683a46ca4c
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.27.0@sha256:f838389131ae30cd52c464d9b9690aa20b429a84aa57842c653c72dd756f9290
+        image: index.docker.io/sourcegraph/gitserver:3.27.1@sha256:4d39a625f4da6323a1309d875e9a7361b0228de6ae07aee0cff50ee8b93eb0f4
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.27.0@sha256:a2630526d27c66151441439befd077c15e1b54c197d3004a7430a85769f15988
+        image: index.docker.io/sourcegraph/grafana:3.27.1@sha256:7568527f17db4482ed5fc1ef6586183e93a35dfedb923ce90140166efd70e401
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.27.0@sha256:9e11b8c7e14e31df91721b61ee1e53073dcb45f2d67ab87b3a0c282a24e0bc5c
+        image: index.docker.io/sourcegraph/indexed-searcher:3.27.1@sha256:696a4f67648f8ba31afac10c0d2de50e4aed1879db0aa6078e55091ac27ba744
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.27.0@sha256:c9eaaf13b9b9ffa69b04f18ee8880877879468e346a9967d687babd972053211
+        image: index.docker.io/sourcegraph/search-indexer:3.27.1@sha256:fca283229a64c5339fde91088c923432436dd47626b5963a38d12567b1e02994
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.27.0@sha256:fd51263505ccb3a43464909959152ecb2bf33b0ea787009a099b4a075c6f23b1
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.27.1@sha256:677f565e9d10eeca3e39622f15c7ad9484654914ac9d7146a11e0e4450bc3679
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.27.0@sha256:e534fd638ee25fb730bd53cd4633b28e4d8f8383580857e3bb45ad36f64929fe
+        image: index.docker.io/sourcegraph/minio:3.27.1@sha256:e534fd638ee25fb730bd53cd4633b28e4d8f8383580857e3bb45ad36f64929fe
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:3.27.0@sha256:4db4ff099d6aa6b6de9f3fd30407f6173509fdd8b65bfe1a24ef3a939aad4eaf
+        image: sourcegraph/postgres_exporter:3.27.1@sha256:2b1cfe5c4d08be6173c4f8277a31ca145972cc17523ab0443221bc1a874c685c
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.27.0@sha256:3bab23b8d2602edf58f0d353332f83d8f6e6c11b48d4d4ac3b17c13b78ce4631
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.27.1@sha256:fc1bc8397d0110faba745b22d7750cecffa4b2a9d966a512105665f3701662d8
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.27.0@sha256:11724079d6a4bcd8433557605422e7ab0bee5df54aff995936ad016050ea6744
+        image: index.docker.io/sourcegraph/prometheus:3.27.1@sha256:0b185a870708e0a270ea5b4c3073abde7354fb34985a18641c59ff5443a795bb
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.27.0@sha256:c78704459cc81e74a4ec8c84337475aac504b4378f405724f66c059cc1f51cec
+        image: index.docker.io/sourcegraph/query-runner:3.27.1@sha256:e01ae3472af9f81be211f56fccbd22c2b8a84d15d8d29f7aa206172994876672
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.27.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.27.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.27.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.27.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.27.0@sha256:7766fa775aee6ce36baee4cd130fd7031f0a211bc56b1f97182ed7204912d2f2
+        image: index.docker.io/sourcegraph/repo-updater:3.27.1@sha256:4e8515aa45f2245b9e83e5e7a1cb807bc63426f0d5d2e82e570fcedc7c49f12b
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -61,7 +61,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.27.0@sha256:3f501ddfdbe815f591ed00ce24ea0da9247c6f3e245448616582408cdc673e96
+        image: index.docker.io/sourcegraph/searcher:3.27.1@sha256:f6f4d94d0131acbc8251a5ef91d71cca177c98c137e4e65636465793cdb5db1b
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.27.0@sha256:b048f475cbce614126d341cdb3a43526da064130a53cb36a0be0a72c3ce7ba14
+        image: index.docker.io/sourcegraph/symbols:3.27.1@sha256:fbabe98351e3bb45ebabfbed6684cd9070bc85381b9d801af81cd3b5e726a5c9
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.0@sha256:2de9985647bd7191d16cf691d2e3063fae3ba6c55f9be5135dff017a0dcf9844
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.27.0@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.27.1@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.27.1 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.27.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/20315)