### PR TITLE
release: sourcegraph@3.27.2

### DIFF
--- a/.buildkite/verify-release/verify-release.go
+++ b/.buildkite/verify-release/verify-release.go
@@ -102,10 +102,14 @@ func (e *validationError) Error() string {
 }
 
 func isReleaseBranch(branch string) bool {
+	if verbose {
+		log.Printf("branch = %q", branch)
+	}
+
 	version := strings.TrimPrefix(branch, "publish-")
 
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v:%s", version)
+		version = fmt.Sprintf("v%s", version)
 	}
 
 	return semver.IsValid(version)

--- a/.buildkite/verify-release/verify-release.go
+++ b/.buildkite/verify-release/verify-release.go
@@ -102,8 +102,13 @@ func (e *validationError) Error() string {
 }
 
 func isReleaseBranch(branch string) bool {
-	v := strings.TrimPrefix(branch, "publish-")
-	return semver.IsValid(v)
+	version := strings.TrimPrefix(branch, "publish-")
+
+	if !strings.HasPrefix(version, "v") {
+		version = fmt.Sprintf("v:%s", version)
+	}
+
+	return semver.IsValid(version)
 }
 
 func getBranch() (string, error) {

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.27.1@sha256:695145832e9cb9fcdd286ceaf542454565135760cb59798e6379b2315708d79d
+        image: index.docker.io/sourcegraph/cadvisor:3.27.2@sha256:8fe335b90b768ed6081f0cb036bfbe757d512da80341524409350f70d3a0495b
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
+        image: index.docker.io/sourcegraph/codeinsights-db:3.27.2@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.27.1@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
+        image: index.docker.io/sourcegraph/codeintel-db:3.27.2@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.27.1@sha256:de14a364d6022bd3a96c3cb62a210fee2e5df55344e89544c2e8396869dff653
+        image: index.docker.io/sourcegraph/frontend:3.27.2@sha256:5b7874ce53c656015746817a1b6d1c4bcd80e94349b7d8529191b6b137d0c7ce
         args:
         - serve
         env:
@@ -106,7 +106,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.27.1@sha256:6e6f77177bca3a8c8539f340e43892fe92f09198054709b6a40f43683a46ca4c
+        image: index.docker.io/sourcegraph/github-proxy:3.27.2@sha256:ffcdfc1fa859ee9af9a786458f2789603ae311847dba553a4c4bcfa682d57c2a
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.27.1@sha256:4d39a625f4da6323a1309d875e9a7361b0228de6ae07aee0cff50ee8b93eb0f4
+        image: index.docker.io/sourcegraph/gitserver:3.27.2@sha256:c2a7919f9f2514dc71f663d9d9e341dbb9344243ab8ab29906418c4980cc62f6
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.27.1@sha256:7568527f17db4482ed5fc1ef6586183e93a35dfedb923ce90140166efd70e401
+        image: index.docker.io/sourcegraph/grafana:3.27.2@sha256:94bb4eef9c96910bacf36035dddaeb042d0eb846a3d8ccfa2994bb3435afb03b
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.27.1@sha256:696a4f67648f8ba31afac10c0d2de50e4aed1879db0aa6078e55091ac27ba744
+        image: index.docker.io/sourcegraph/indexed-searcher:3.27.2@sha256:696a4f67648f8ba31afac10c0d2de50e4aed1879db0aa6078e55091ac27ba744
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.27.1@sha256:fca283229a64c5339fde91088c923432436dd47626b5963a38d12567b1e02994
+        image: index.docker.io/sourcegraph/search-indexer:3.27.2@sha256:fca283229a64c5339fde91088c923432436dd47626b5963a38d12567b1e02994
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.27.1@sha256:677f565e9d10eeca3e39622f15c7ad9484654914ac9d7146a11e0e4450bc3679
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.27.2@sha256:89497f33880ca8c9110eb84113a81d084a92ea1921820cf24ff4c215c4bf7f34
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.27.1@sha256:e534fd638ee25fb730bd53cd4633b28e4d8f8383580857e3bb45ad36f64929fe
+        image: index.docker.io/sourcegraph/minio:3.27.2@sha256:e534fd638ee25fb730bd53cd4633b28e4d8f8383580857e3bb45ad36f64929fe
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6:91468_2021-03-30_b77d2e6@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
+        image: index.docker.io/sourcegraph/postgres-12.6:3.27.2@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:3.27.1@sha256:2b1cfe5c4d08be6173c4f8277a31ca145972cc17523ab0443221bc1a874c685c
+        image: sourcegraph/postgres_exporter:3.27.2@sha256:9bf5e71a39d0b83944e5b6a2300f6e2a8f2a94c12527916d28d2e98867be464f
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.27.1@sha256:fc1bc8397d0110faba745b22d7750cecffa4b2a9d966a512105665f3701662d8
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.27.2@sha256:24e7a7b3c9bb9448bc804e8d48c9c748dd8f4f8fca7bd2ace9519d00720c704a
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.27.1@sha256:0b185a870708e0a270ea5b4c3073abde7354fb34985a18641c59ff5443a795bb
+        image: index.docker.io/sourcegraph/prometheus:3.27.2@sha256:a2e417a8e9334e5b4d6a87205ee8cb81aff695cae633d0e279a95460df60f9a7
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.27.1@sha256:e01ae3472af9f81be211f56fccbd22c2b8a84d15d8d29f7aa206172994876672
+        image: index.docker.io/sourcegraph/query-runner:3.27.2@sha256:ae684f8754c7d4a00c75ebd5b4d9686c2b9573a0b759ccaf132ca25efa142418
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.27.1@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.27.2@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter
-        image: index.docker.io/sourcegraph/redis_exporter:84464_2021-01-15_c2e4c28@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.27.2@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.27.1@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.27.2@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter    
-        image: index.docker.io/sourcegraph/redis_exporter:84464_2021-01-15_c2e4c28@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.27.2@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.27.1@sha256:4e8515aa45f2245b9e83e5e7a1cb807bc63426f0d5d2e82e570fcedc7c49f12b
+        image: index.docker.io/sourcegraph/repo-updater:3.27.2@sha256:2f2eca800056f32d5e4f5ff9e0e8d87127c17e98291fd6dbd985fb6e390c192a
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -61,7 +61,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.27.1@sha256:f6f4d94d0131acbc8251a5ef91d71cca177c98c137e4e65636465793cdb5db1b
+        image: index.docker.io/sourcegraph/searcher:3.27.2@sha256:d6a4b7e1266500ff190332ccca7868819cede69be530ae7a6ad5c22b7db67cdd
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.27.1@sha256:fbabe98351e3bb45ebabfbed6684cd9070bc85381b9d801af81cd3b5e726a5c9
+        image: index.docker.io/sourcegraph/symbols:3.27.2@sha256:8b90bf15baa08399bbe1502390e0479f6569310e069f06b8148cfbcde9baa8a1
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.27.1@sha256:c5587dd45e1b4f1688eb3b7743aa2ade551c00fe1d5e0d6b43ce6b603d29245a
+        image: index.docker.io/sourcegraph/jaeger-agent:3.27.2@sha256:b5bc64168c7d28a11f55ce7ed473ec3f7ff4e7d984606abc6f74513667d45d85
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.27.1@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.27.2@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.27.2 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.27.2)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/20377)