### PR TITLE
Update sourcegraph/postgres-12.6 images to latest

### DIFF
--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6:91468_2021-03-30_b77d2e6@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
+        image: index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:


### PR DESCRIPTION
This PR updates images that use sourcegraph/postgres-12

[_Created by Sourcegraph batch change `andre/update-postgres12.6-base-images`._](https://k8s.sgdev.org/users/andre/batch-changes/update-postgres12.6-base-images)