### PR TITLE
Set ephemeral storage to match cache

### DIFF
--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -30,7 +30,9 @@ spec:
       - name: searcher
         env:
         - name: SEARCHER_CACHE_SIZE_MB
-          value: "50000"
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.resources.requests.ephemeral-storage
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -31,8 +31,9 @@ spec:
         env:
         - name: SEARCHER_CACHE_SIZE_MB
           valueFrom:
-            fieldRef:
-              fieldPath: spec.resources.requests.ephemeral-storage
+            resourceFieldRef:
+              containerName: searcher
+              resource: requests.ephemeral-storage
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
       - name: searcher
         env:
         - name: SEARCHER_CACHE_SIZE_MB
-          value: "100000"
+          value: "50000"
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -55,11 +55,11 @@ spec:
         resources:
           limits:
             cpu: "2"
-            ephemeral-storage: "8Gi"
+            ephemeral-storage: "51G"
             memory: 2G
           requests:
             cpu: 500m
-            ephemeral-storage: "4Gi"
+            ephemeral-storage: "50G"
             memory: 500M
         volumeMounts:
         - mountPath: /mnt/cache

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: searcher
 spec:
   minReadySeconds: 10
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -58,11 +58,11 @@ spec:
         resources:
           limits:
             cpu: "2"
-            ephemeral-storage: "51G"
+            ephemeral-storage: "26G"
             memory: 2G
           requests:
             cpu: 500m
-            ephemeral-storage: "50G"
+            ephemeral-storage: "25G"
             memory: 500M
         volumeMounts:
         - mountPath: /mnt/cache

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -31,8 +31,9 @@ spec:
         env:
         - name: SYMBOLS_CACHE_SIZE_MB
           valueFrom:
-            fieldRef:
-              fieldPath: spec.resources.requests.ephemeral-storage
+            resourceFieldRef:
+              containerName: symbols
+              resource: requests.ephemeral-storage
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -30,7 +30,9 @@ spec:
       - name: symbols
         env:
         - name: SYMBOLS_CACHE_SIZE_MB
-          value: "10000"
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.resources.requests.ephemeral-storage
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!-- description here -->
Related to https://github.com/sourcegraph/deploy-sourcegraph/pull/2369

Fixes https://github.com/sourcegraph/sourcegraph/issues/20869

If these values differ, the pod will be evicted for exceeding its storage allotment

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [x] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [x] All images have a valid tag and SHA256 sum
