### PR TITLE
Update redis-store.Deployment.yaml

### DIFF
--- a/overlays/non-root-create-cluster/redis/redis-store.Deployment.yaml
+++ b/overlays/non-root-create-cluster/redis/redis-store.Deployment.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       securityContext:
-        fsGroup: 999
+        fsGroup: 1000


### PR DESCRIPTION
Fixes error where redis cannot write to filesystem due to incorrect ownership on filesystem. 

Match to redis group in non-root overlay https://github.com/sourcegraph/deploy-sourcegraph/blob/master/overlays/non-root/redis/redis-store.Deployment.yaml#L20

