### PR TITLE
user newer alpine image for overlays

### DIFF
--- a/overlays/migrate-to-nonroot/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/frontend/sourcegraph-frontend.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
           - mountPath: /mnt/cache

--- a/overlays/migrate-to-nonroot/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/migrate-to-nonroot/gitserver/gitserver.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /data/repos)\" -ne 100 ]]; then chown -R 100:101 /data/repos; fi"]
           volumeMounts:
             - mountPath: /data/repos

--- a/overlays/migrate-to-nonroot/grafana/grafana.StatefulSet.yaml
+++ b/overlays/migrate-to-nonroot/grafana/grafana.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 472:472 /var/lib/grafana"]
           volumeMounts:
             - mountPath: /var/lib/grafana

--- a/overlays/migrate-to-nonroot/indexed-search/indexed-search.StatefulSet.yaml
+++ b/overlays/migrate-to-nonroot/indexed-search/indexed-search.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
             - mountPath: /data

--- a/overlays/migrate-to-nonroot/minio/minio.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/minio/minio.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
           - mountPath: /data

--- a/overlays/migrate-to-nonroot/prometheus/prometheus.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/prometheus/prometheus.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 100:100 /prometheus"]
           volumeMounts:
             - mountPath: /prometheus

--- a/overlays/migrate-to-nonroot/redis/redis-cache.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/redis/redis-cache.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonroot/redis/redis-store.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/redis/redis-store.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonroot/searcher/searcher.Deployment.yaml
+++ b/overlays/migrate-to-nonroot/searcher/searcher.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+          image: sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb0a849a393b87d94fb174
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
             - mountPath: /mnt/cache


### PR DESCRIPTION
this change uses a newer alpine image to perform updates during the conversion from root to non-root containers

[_Created by Sourcegraph batch change `dave/alpine-update`._](https://k8s.sgdev.org/users/dave/batch-changes/alpine-update)