### PR TITLE
release: sourcegraph@3.29.1

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.29.0@sha256:6bcd66870121487ace86608f076126423b0ba82351d77ba3dd555738b13ae7d0
+        image: index.docker.io/sourcegraph/cadvisor:3.29.1@sha256:395e7b6b0f24f8aab511f22aa86e3dcb969e455e3bf0e512ce8b2831756fc912
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:3.29.0@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
+        image: index.docker.io/sourcegraph/codeinsights-db:3.29.1@sha256:f985af2fef860cc48be40ded864df025b8794b02b86e66cbc6c55bfe3c418831
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.29.0@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
+        image: index.docker.io/sourcegraph/codeintel-db:3.29.1@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -73,7 +73,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/code_intel_queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.29.0@sha256:6b2525f8e9c33d64ddcfafca637c8e1f81e30b89eb907ea7e894bd18651e31e8
+        image: index.docker.io/sourcegraph/postgres_exporter:3.29.1@sha256:a81d572b77e1a0841272dd793ce36a8bdd46183a9e6a888322259117d0a89b4d
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.29.0@sha256:52ab0377a3b94663c15ff098305275bca11592342e32f1729b53f59fe84c42a4
+        image: index.docker.io/sourcegraph/frontend:3.29.1@sha256:ce659cb1a065ca295e2b209299eeb2c50a251a84dae54c27818273001e23f59e
         args:
         - serve
         env:
@@ -106,7 +106,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.29.0@sha256:12f53692d555100828a79aabef09927faa7818e1151bfe3f2bb383a9a47e8a4a
+        image: index.docker.io/sourcegraph/github-proxy:3.29.1@sha256:68cdda9e9e3795b2da841b2a6ef5665e14b93a051cee9809bc9081fc04e48d7a
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.29.0@sha256:03aacb13fdb9a30bba7113c095ba0953a016df9edf7f1059cee6db8cce3571c6
+        image: index.docker.io/sourcegraph/gitserver:3.29.1@sha256:7c58baf8a36335ca86197c9d2c2db2c351f608a574973ce06b4790cc36ce9b0a
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.29.0@sha256:806aeebb2aa107ab1b1cc6b86dceab3350546950bfde93152ab1f17a43951bba
+        image: index.docker.io/sourcegraph/grafana:3.29.1@sha256:d391dfbe7b8d8fc2fa5f7c33ec4c909c2f258383984462ce64c8994dad15a787
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.29.0@sha256:45e49dc5e188b0cfcdbee7d411c75d69b290bc1d933d801084374cdb8ea11e95
+        image: index.docker.io/sourcegraph/indexed-searcher:3.29.1@sha256:45e49dc5e188b0cfcdbee7d411c75d69b290bc1d933d801084374cdb8ea11e95
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.29.0@sha256:5675107888a618b47603759739c3f82ff90106dd06c68b017fa8ac65e8778ab6
+        image: index.docker.io/sourcegraph/search-indexer:3.29.1@sha256:5675107888a618b47603759739c3f82ff90106dd06c68b017fa8ac65e8778ab6
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.29.0@sha256:7e77fd0afe518bdfc4cf02498805afe391102c89a5a1928280fdc3bf1ae19a21
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.29.1@sha256:7722a13208fe6f8de68ad644c2e7ac2bfd87f7ad7c0e470f1df2ebec73d98ba7
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.29.0@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
+        image: index.docker.io/sourcegraph/minio:3.29.1@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6:3.29.0@sha256:cf3eb6a0a6e61a3dfab2394e01565ecb49082f40fd616210bf6a843fa8e82be6
+        image: index.docker.io/sourcegraph/postgres-12.6:3.29.1@sha256:2d8bbfc7d954beb7d300261dfa9ad54bc6087ac16252b6bc1dd33ffec800ae46
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -74,7 +74,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.29.0@sha256:6b2525f8e9c33d64ddcfafca637c8e1f81e30b89eb907ea7e894bd18651e31e8
+        image: index.docker.io/sourcegraph/postgres_exporter:3.29.1@sha256:a81d572b77e1a0841272dd793ce36a8bdd46183a9e6a888322259117d0a89b4d
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.29.0@sha256:7b9f5f5169b47e86290a7d1a0a395ea41c9bcf62820388aeb1bbbaaf93d7d5f2
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.29.1@sha256:364d097cce739ec158af2b795c6cb4402f296d9f761d4d8d2cbefa5a45e4a06e
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.29.0@sha256:cb8b42aad850a223ed9ebcdb3e8b4ae51280b38c79ec9353ea1266adad7afd93
+        image: index.docker.io/sourcegraph/prometheus:3.29.1@sha256:5d8b0fdb4bf012b11bdf0bfa79de755ab2ea3c132dcb3e65a7884253106c8989
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.29.0@sha256:692aff4bf671b2e62249bf8034cf44c9bdcf4a4e52edadee3989cd3f10d56a59
+        image: index.docker.io/sourcegraph/query-runner:3.29.1@sha256:dca71f41bf6244d903e87753c614c93e76aaea1d6876ed4324b7986047ab1efa
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.29.0@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
+        image: index.docker.io/sourcegraph/redis-cache:3.29.1@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter
-        image: index.docker.io/sourcegraph/redis_exporter:3.29.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.29.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.29.0@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
+        image: index.docker.io/sourcegraph/redis-store:3.29.1@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter    
-        image: index.docker.io/sourcegraph/redis_exporter:3.29.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.29.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.29.0@sha256:f9084a6aeb1bd2e9aecdf62c85e92e273f7a6cd564cb38f33a7ae9512426044a
+        image: index.docker.io/sourcegraph/repo-updater:3.29.1@sha256:247d27867f4be321dd371560ea21c47071c36c334cfcb3a56f1d413890b482e7
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -61,7 +61,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.29.0@sha256:5a9f427f78caf2a9d5861a74a174fd83d4fb702b61e49ed367a693c9d4c2c2ee
+        image: index.docker.io/sourcegraph/searcher:3.29.1@sha256:907c403a9e1b24b25d8b099e155bb4d22e3399cf985bf2119217b0797f7e57f3
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -65,7 +65,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -37,7 +37,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.29.0@sha256:bc5f6cf260c7e181d118f5e5bebfc4e4eb905d785e236de2e8c16f89f537043e
+        image: index.docker.io/sourcegraph/symbols:3.29.1@sha256:eb4ab149e6eea7601dd7335df35b505649204f9a47e0c83efcfbc595d6f8914b
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -71,7 +71,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.29.0@sha256:0d206463f6787bb0b57528a1f029800ede2d9ede1c133d42009c6eccd5be098b
+        image: index.docker.io/sourcegraph/jaeger-agent:3.29.1@sha256:a55bea6770fe33d2260262f4b55a13f44dba4b32fc3ae942015ea0cfed459d75
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.29.0@sha256:1d2ac738eec37f8a3ac4da3d73350a4f9be6a2d730074f07ce42dd9dd978b5fc
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.29.1@sha256:1d2ac738eec37f8a3ac4da3d73350a4f9be6a2d730074f07ce42dd9dd978b5fc
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/worker/worker.Deployment.yaml
+++ b/base/worker/worker.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/worker:3.29.0@sha256:b61d6136988b6abe56ee890440c35a63fb99de6ce5e09a3cb0cbfe7a03a0ec15
+        image: index.docker.io/sourcegraph/worker:3.29.1@sha256:b0e4900f4ad41288b3c84e7ab7ac7e5a2e2355150f3d400b29ae8a018ac4ee8f
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.29.1 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.29.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/22397)