### PR TITLE
release: sourcegraph@3.30.1

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.30.0@sha256:7d5265648eaf090d1fa39e2b483b09e34db592291a6d430f43f0d0ed6f80f848
+        image: index.docker.io/sourcegraph/cadvisor:3.30.1@sha256:dedfdb48853f49f0124c6d16678b714b04cc41509ae264c649b50414f0a4f92c
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:3.30.0@sha256:f96ee58ffb3610c032f03b9e63b32f3b074fd0791333142414b6b756bccabf28
+        image: index.docker.io/sourcegraph/codeinsights-db:3.30.1@sha256:4b1dfac1028bcb5a77565b62db634d3f1a5da5b45dbac21c0a87ae6995cb609a
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.30.0@sha256:4942c0fb6acc6227e0cdb9ee6ee1a917bc121638d61e2961a637546b0e828426
+        image: index.docker.io/sourcegraph/codeintel-db:3.30.1@sha256:dbcb0c7faa13174a90dda7a3b93039c1698388f27e87a4e8a16d3fcaa4927d8e
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -73,7 +73,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/code_intel_queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.30.0@sha256:fd803f68f57b98aa524282049209e5d687cb1fde1832a95b0a70574db4e8c7e7
+        image: index.docker.io/sourcegraph/postgres_exporter:3.30.1@sha256:77f974d60dcda87460e438a4a08100f4d201e2213d60775c993cc4164a963b32
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.30.0@sha256:2f894784f3d9f9f8b6058456626659f3255ae4c039ef62d288c6d59072e2dd43
+        image: index.docker.io/sourcegraph/frontend:3.30.1@sha256:4eaa8872e81d81928ca90af05f1459dc727bd812f6775eaa7cc63e9090abfcab
         args:
         - serve
         env:
@@ -106,7 +106,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.30.0@sha256:f0f2aad909bf8221cbf2c8961daf8e0a3c3a1d61da076a19ed944aecb7d6ca9a
+        image: index.docker.io/sourcegraph/github-proxy:3.30.1@sha256:235ef9a29995bfbcdd49ea4d9be820e125339fe2058149904761120f464f42c2
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.30.0@sha256:61f8768f0d5c0a748cfcb989202c4f80075458b0daec55b0489d22eb12157b29
+        image: index.docker.io/sourcegraph/gitserver:3.30.1@sha256:3e5a6b8cf7dc778c42170f44413d3ce3f456ce3e8e521d195e81f8ae798c42a0
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.30.0@sha256:90384cabbd56c06e7f40c85116187e19a2b07c7f5ab3fe87ceab05585ba68fc1
+        image: index.docker.io/sourcegraph/grafana:3.30.1@sha256:8f1ad0ad16cbfaa458263da920b722af9312227608902f7470ddb33dcd209307
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.30.0@sha256:ede7be935ab07792cdf7a508e01dc5316915e30e8661c270d8d1c4f15c9ebd15
+        image: index.docker.io/sourcegraph/indexed-searcher:3.30.1@sha256:ede7be935ab07792cdf7a508e01dc5316915e30e8661c270d8d1c4f15c9ebd15
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.30.0@sha256:5e9a2f7cdc3f46d84d3eaa03b8473d5a5850a7082291e3da961781d858b05a84
+        image: index.docker.io/sourcegraph/search-indexer:3.30.1@sha256:5e9a2f7cdc3f46d84d3eaa03b8473d5a5850a7082291e3da961781d858b05a84
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.30.0@sha256:297571e3a35b9742fc4120fe2e0259bbe103bdfd65cffe480bec5044ff232dea
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.30.1@sha256:303d9e6fdf8aa913cb01d6ab6a73e849fccb7ac9c9c830a473f63a4853a1d9ae
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.30.0@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
+        image: index.docker.io/sourcegraph/minio:3.30.1@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6-alpine:3.30.0@sha256:439246675646322cf6b22a277ab86d790287bc4c532e2a2f4a4e0538d06cd206
+        image: index.docker.io/sourcegraph/postgres-12.6-alpine:3.30.1@sha256:329766fdbbd821be9579627b5d3a0a24dc8a58f251195e6102afef5a402dc456
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -74,7 +74,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.30.0@sha256:fd803f68f57b98aa524282049209e5d687cb1fde1832a95b0a70574db4e8c7e7
+        image: index.docker.io/sourcegraph/postgres_exporter:3.30.1@sha256:77f974d60dcda87460e438a4a08100f4d201e2213d60775c993cc4164a963b32
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.30.0@sha256:eb368c50614cd74aef57d4d9a491bf590e1cd55590bbdf4070c31fa6b6e6c365
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.30.1@sha256:c6ccec7416f21805de6e06a823d26eb7bb739dd8b2ca9ac0d24cc7f2d6a6194c
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.30.0@sha256:6e9d0f957c3ca358e558dd74d22a140f55d09ca890b184721e2be6482386b608
+        image: index.docker.io/sourcegraph/prometheus:3.30.1@sha256:8adb388b78641f8340b2e4bae413ae8e994aedf28395f785da9c8240f7f0e0cf
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.30.0@sha256:297fccfa2f81d279f1cc0fe61e1816a0fbfd1b0cef1bc4e8048dd013f7c8c5d5
+        image: index.docker.io/sourcegraph/query-runner:3.30.1@sha256:ecef7cccf5533615df748056ef2615dda1e3eb9586b838d742eadf4763e5ad57
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.30.0@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
+        image: index.docker.io/sourcegraph/redis-cache:3.30.1@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter
-        image: index.docker.io/sourcegraph/redis_exporter:3.30.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.30.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.30.0@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
+        image: index.docker.io/sourcegraph/redis-store:3.30.1@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter    
-        image: index.docker.io/sourcegraph/redis_exporter:3.30.0@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.30.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.30.0@sha256:c96c150e42f7017c7d5f5636bf50a13b65795d957763356d7fda045472e23e5c
+        image: index.docker.io/sourcegraph/repo-updater:3.30.1@sha256:a0d9ad040ed389aad5a4c4b8050e5ce741ac73d33eb453dc81f14d2dce5bfd3d
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -61,7 +61,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.30.0@sha256:c44bce7c4f8a8cbddddf7d8ab0db5bc60ca2ec554fd120929ae9791181a08d50
+        image: index.docker.io/sourcegraph/searcher:3.30.1@sha256:4c63605868738628bf40158865ee0caae601ba4fbe4a944905c9314889f67fee
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -68,7 +68,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.30.0@sha256:60dcad38e2414a4b5aacf69747df99e1a414ad164adf42518c3989f2001938c6
+        image: index.docker.io/sourcegraph/symbols:3.30.1@sha256:d379d012f812d3d740b822f485ae343c41fe9771b5339b5c5b27becd76decc1b
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -74,7 +74,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.0@sha256:f64493c35f8a2b24b83440b066861afa437dd5a09e61b03a7aab886b1b1779d0
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.30.0@sha256:8854665264522a86b711c732d803395478dab30f6df6197b5d0c1c7c21cd6261
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.30.1@sha256:8854665264522a86b711c732d803395478dab30f6df6197b5d0c1c7c21cd6261
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/worker/worker.Deployment.yaml
+++ b/base/worker/worker.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/worker:3.30.0@sha256:a6318f5ec2201e79c24a7f7353c2ba8dcabef2382f835d5d85151bfc3ebb7ad2
+        image: index.docker.io/sourcegraph/worker:3.30.1@sha256:cd29474983df177db7cf4e6bb2469a429328ce5418d6e0abc700e3322173e935
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.30.1 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.30.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/23143)