### PR TITLE
release: sourcegraph@3.30.2

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:3.30.1@sha256:dedfdb48853f49f0124c6d16678b714b04cc41509ae264c649b50414f0a4f92c
+        image: index.docker.io/sourcegraph/cadvisor:3.30.2@sha256:78bbda3d1372b4b5f960c2784a301c711b0f132b6839532f91b4ef05932ec606
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:3.30.1@sha256:4b1dfac1028bcb5a77565b62db634d3f1a5da5b45dbac21c0a87ae6995cb609a
+        image: index.docker.io/sourcegraph/codeinsights-db:3.30.2@sha256:3115e1ad73a4113c7bbd1dc1109a86479963403d762f4220285b30ac06013a64
         env:
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - name: pgsql
-        image: index.docker.io/sourcegraph/codeintel-db:3.30.1@sha256:dbcb0c7faa13174a90dda7a3b93039c1698388f27e87a4e8a16d3fcaa4927d8e
+        image: index.docker.io/sourcegraph/codeintel-db:3.30.2@sha256:d259bc12cab7f06394a6f36042c44856d68c8107973308b8be367ace31f0476c
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -73,7 +73,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/code_intel_queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.30.1@sha256:77f974d60dcda87460e438a4a08100f4d201e2213d60775c993cc4164a963b32
+        image: index.docker.io/sourcegraph/postgres_exporter:3.30.2@sha256:61a58114adc19d7f73b8529e9d971a93775e354b5498d7087efb7f0275b30576
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:3.30.1@sha256:4eaa8872e81d81928ca90af05f1459dc727bd812f6775eaa7cc63e9090abfcab
+        image: index.docker.io/sourcegraph/frontend:3.30.2@sha256:8f2d83ea37bddea634d34fc0a14f07fa353fe87a00e6d3730bb188e97101e611
         args:
         - serve
         env:
@@ -106,7 +106,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: github-proxy
-        image: index.docker.io/sourcegraph/github-proxy:3.30.1@sha256:235ef9a29995bfbcdd49ea4d9be820e125339fe2058149904761120f464f42c2
+        image: index.docker.io/sourcegraph/github-proxy:3.30.2@sha256:41ca048f22553b426948f7545e691210ade8950da06708c6811c2d01d5267e25
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3180
@@ -41,7 +41,7 @@ spec:
             cpu: 100m
             memory: 250M
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: gitserver
         args: ["run"]
-        image: index.docker.io/sourcegraph/gitserver:3.30.1@sha256:3e5a6b8cf7dc778c42170f44413d3ce3f456ce3e8e521d195e81f8ae798c42a0
+        image: index.docker.io/sourcegraph/gitserver:3.30.2@sha256:eee736c497ffed216efa01e20de335dafc06bc93794301be034f6bf2ee49cdb9
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -51,7 +51,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: index.docker.io/sourcegraph/grafana:3.30.1@sha256:8f1ad0ad16cbfaa458263da920b722af9312227608902f7470ddb33dcd209307
+        image: index.docker.io/sourcegraph/grafana:3.30.2@sha256:b632aa6d376d6e40568db8d12a27437fa0f5f95c241795526b979e7034882bf6
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3370

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: zoekt-webserver
-        image: index.docker.io/sourcegraph/indexed-searcher:3.30.1@sha256:ede7be935ab07792cdf7a508e01dc5316915e30e8661c270d8d1c4f15c9ebd15
+        image: index.docker.io/sourcegraph/indexed-searcher:3.30.2@sha256:ede7be935ab07792cdf7a508e01dc5316915e30e8661c270d8d1c4f15c9ebd15
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6070
@@ -47,7 +47,7 @@ spec:
         - mountPath: /data
           name: data
       - name: zoekt-indexserver
-        image: index.docker.io/sourcegraph/search-indexer:3.30.1@sha256:5e9a2f7cdc3f46d84d3eaa03b8473d5a5850a7082291e3da961781d858b05a84
+        image: index.docker.io/sourcegraph/search-indexer:3.30.2@sha256:5e9a2f7cdc3f46d84d3eaa03b8473d5a5850a7082291e3da961781d858b05a84
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 6072

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
         containers:
         - name: jaeger
-          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.30.1@sha256:303d9e6fdf8aa913cb01d6ab6a73e849fccb7ac9c9c830a473f63a4853a1d9ae
+          image: index.docker.io/sourcegraph/jaeger-all-in-one:3.30.2@sha256:ef14add94cfacc816f51edda194f640ae3e0359063f16e424d2d90f951ab0c1a
           args: ["--memory.max-traces=20000"]
           ports:
             - containerPort: 5775

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:3.30.1@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
+        image: index.docker.io/sourcegraph/minio:3.30.2@sha256:4f39c3fa2ecf208c0df013e36883d25c3eb8a88ec10d6b1718c2f2b62a34c665
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         ports:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -42,7 +42,7 @@ spec:
             memory: "50Mi"
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6-alpine:3.30.1@sha256:329766fdbbd821be9579627b5d3a0a24dc8a58f251195e6102afef5a402dc456
+        image: index.docker.io/sourcegraph/postgres-12.6:3.30.2@sha256:10aef727716edd046e9e6640e41a4c8c60f5d4630c9b19423e4ae5327b6ff887
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -74,7 +74,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: index.docker.io/sourcegraph/postgres_exporter:3.30.1@sha256:77f974d60dcda87460e438a4a08100f4d201e2213d60775c993cc4164a963b32
+        image: index.docker.io/sourcegraph/postgres_exporter:3.30.2@sha256:61a58114adc19d7f73b8529e9d971a93775e354b5498d7087efb7f0275b30576
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.30.1@sha256:c6ccec7416f21805de6e06a823d26eb7bb739dd8b2ca9ac0d24cc7f2d6a6194c
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.30.2@sha256:65a3618779cfb3099b4ddd596e6a798f9c253b5452d4e87315129b90b6b9ddb4
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: index.docker.io/sourcegraph/prometheus:3.30.1@sha256:8adb388b78641f8340b2e4bae413ae8e994aedf28395f785da9c8240f7f0e0cf
+        image: index.docker.io/sourcegraph/prometheus:3.30.2@sha256:f972e4b825ed313db332b92503cfea2241a5ac4ccac77e26f1e88455d064fd64
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: query-runner
-        image: index.docker.io/sourcegraph/query-runner:3.30.1@sha256:ecef7cccf5533615df748056ef2615dda1e3eb9586b838d742eadf4763e5ad57
+        image: index.docker.io/sourcegraph/query-runner:3.30.2@sha256:6872aaf205abf6260d15e4130e5ab3654cf79f199e6029c99577289a2a12921e
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3183
@@ -40,7 +40,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-cache
-        image: index.docker.io/sourcegraph/redis-cache:3.30.1@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
+        image: index.docker.io/sourcegraph/redis-cache:3.30.2@sha256:35245d84f0d154d12501ea4b997fa21913939cc4ce7c4de288b44d1d7e50624c
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter
-        image: index.docker.io/sourcegraph/redis_exporter:3.30.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.30.2@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: redis-store
-        image: index.docker.io/sourcegraph/redis-store:3.30.1@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
+        image: index.docker.io/sourcegraph/redis-store:3.30.2@sha256:5e9fec6f4f9801fcd012a5eb4d35d1f50e9e7c6aad2733790698ab28b8378930
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30
@@ -49,7 +49,7 @@ spec:
         - mountPath: /redis-data
           name: redis-data
       - name: redis-exporter    
-        image: index.docker.io/sourcegraph/redis_exporter:3.30.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
+        image: index.docker.io/sourcegraph/redis_exporter:3.30.2@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 9121

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: repo-updater
-        image: index.docker.io/sourcegraph/repo-updater:3.30.1@sha256:a0d9ad040ed389aad5a4c4b8050e5ce741ac73d33eb453dc81f14d2dce5bfd3d
+        image: index.docker.io/sourcegraph/repo-updater:3.30.2@sha256:6e78474ca6391a8c2ae98ddfc5d7bd45362adcf89d2829ea9f635844301d0808
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
@@ -61,7 +61,7 @@ spec:
             cpu: "1"
             memory: 500Mi
       - name: jaeger-agent      
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:3.30.1@sha256:4c63605868738628bf40158865ee0caae601ba4fbe4a944905c9314889f67fee
+        image: index.docker.io/sourcegraph/searcher:3.30.2@sha256:8fbc71d9fe8e278984a15d3ec1fdba3d34da47f9be55fa912ff2673bfaa0d17c
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 3181
@@ -68,7 +68,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -40,7 +40,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:3.30.1@sha256:d379d012f812d3d740b822f485ae343c41fe9771b5339b5c5b27becd76decc1b
+        image: index.docker.io/sourcegraph/symbols:3.30.2@sha256:b16adae5cec0bbf210829a314fd04b2502f2238c591b4dcf6ab325d918818b9f
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
@@ -74,7 +74,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:3.30.1@sha256:0b6968e2b64751b9038480ab3fe48c90d9534bda53b1703e16847d5b27aef996
+        image: index.docker.io/sourcegraph/jaeger-agent:3.30.2@sha256:74ea7ce9fe88240c1ab7c7ae267053afed64afa31cd08956461975633501ac43
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: syntect-server
         env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:3.30.1@sha256:8854665264522a86b711c732d803395478dab30f6df6197b5d0c1c7c21cd6261
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.30.2@sha256:8854665264522a86b711c732d803395478dab30f6df6197b5d0c1c7c21cd6261
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/worker/worker.Deployment.yaml
+++ b/base/worker/worker.Deployment.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/worker:3.30.1@sha256:cd29474983df177db7cf4e6bb2469a429328ce5418d6e0abc700e3322173e935
+        image: index.docker.io/sourcegraph/worker:3.30.2@sha256:33aa9e07590747d84324f51c9d53d190004ef4cc217185b8b8d585cdeaab80d2
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.30.2 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.30.2)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/23304)