### PR TITLE
frontend: Remove SRC_GIT_SERVERS env var

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -54,8 +54,6 @@ spec:
           value: disable
         - name: CODEINTEL_PGUSER
           value: sg
-        - name: SRC_GIT_SERVERS
-          value: gitserver-0.gitserver:3178
         # POD_NAME is used by CACHE_DIR
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
In Kubernetes deployments, setting the SRC_GIT_SERVERS environment variable explicitly is no longer needed. Addresses of the gitserver pods will be discovered automatically. Unset it in your frontend.Deployment.yaml to make use of this feature. https://github.com/sourcegraph/sourcegraph/pull/24094