### PR TITLE
update test versions

### DIFF
--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -21,7 +21,7 @@ func TestFreshDeployment(t *testing.T) {
 	noCleanup := os.Getenv("NOCLEANUP") == "true"
 
 	// Validate on various kubernetes versions
-	for _, k8sVersion := range []string{"1.18", "1.19", "1.20"} {
+	for _, k8sVersion := range []string{"1.19", "1.20", "1.21"} {
 		k8sVersion := k8sVersion
 		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {
 			config, err := commonConfig()


### PR DESCRIPTION
1.18 has been sunsetted on GKE so we need to bump our versions. 
