### PR TITLE
Add divisor to resourceFieldRef’s that expect a value in MB instead of bytes

### DIFF
--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -35,6 +35,7 @@ spec:
             resourceFieldRef:
               containerName: searcher
               resource: requests.ephemeral-storage
+              divisor: 1M
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -35,6 +35,7 @@ spec:
             resourceFieldRef:
               containerName: symbols
               resource: requests.ephemeral-storage
+              divisor: 1M
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/26283.

[Limits and requests for ephemeral-storage are measured in bytes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage), and the SEARCHER_CACHE_SIZE_MB / SYMBOLS_CACHE_SIZE_MB var's expect a unit of MB. 

Caveats:
- I'm not sure how to test this change - ideally I'd fill up the cache and confirm it crashes the pod before this change, and works after. How can I make that happen?
**Tested by filling up the disk using dd**
- This will reduce the allowed cache size for any customers adopting this change. I think this will have no impact because the cache was already practically limited by the ephemeral disk size, but I'd appreciate confirmation from someone.
**Not a concern, because caches are per-pod and get recreated on every deployment**

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [x] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
