### PR TITLE
Update minio envvars to new convention

### DIFF
--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -27,9 +27,9 @@ spec:
       containers:
       - name: minio
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: AKIAIOSFODNN7EXAMPLE
-        - name: MINIO_SECRET_KEY
+        - name: MINIO_ROOT_PASSWORD
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
         image: index.docker.io/sourcegraph/minio:insiders@sha256:fccfad6cbd7b717472c7f200cdd65807ff742f883fe1d08986fc09ff3bd7df5e
         args: ['minio', 'server', '/data']


### PR DESCRIPTION
Update minio environment variables to new convention. 
Addresses https://github.com/sourcegraph/sourcegraph/issues/26529.

[_Created by Sourcegraph batch change `kevin.wojkovich/minio-envvar-update`._](https://k8s.sgdev.org/users/kevin.wojkovich/batch-changes/minio-envvar-update)