### PR TITLE
update ingress api version

### DIFF
--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -25,9 +25,12 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: sourcegraph-frontend
-          servicePort: 30080
+          service:
+            name: sourcegraph-frontend
+            port: 
+              number: 30080
     # If you're using TLS/SSL, uncomment the following line and replace 'sourcegraph.example.com' with the real
     # domain that you want to use for your Sourcegraph instance.
     # host: sourcegraph.example.com


### PR DESCRIPTION
update the networking api version to the stable (non-beta) version which is standard from 1.19

fixes https://github.com/sourcegraph/sourcegraph/issues/16808 and https://github.com/sourcegraph/sourcegraph/issues/28154
