### PR TITLE
buildkite: explicitly target queue=standard in CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,18 +1,31 @@
 steps:
   - label: ":k8s:"
     command: .buildkite/verify-yaml.sh
+    agents: { queue: standard }
+
   - label: ":k8s:"
     command: .buildkite/verify-label.sh
+    agents: { queue: standard }
+
   - label: ":k8s:"
     command: .buildkite/verify-rbac-labels.sh
+    agents: { queue: standard }
+
   - label: ':lipstick:'
     command: .buildkite/prettier-check.sh
+    agents: { queue: standard }
+
   - label: ':lipstick:'
     command: .buildkite/shfmt.sh
+    agents: { queue: standard }
+
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
+    agents: { queue: standard }
+
   - label: ":k8s: :sleuth_or_spy:" 
     command: .buildkite/check-image-names.sh
+    agents: { queue: standard }
 
   - wait
 
@@ -25,6 +38,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
+    agents: { queue: standard }
 
   - label: ":k8s:"
     concurrency: 3
@@ -34,3 +48,4 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
+    agents: { queue: standard }


### PR DESCRIPTION
related to https://github.com/sourcegraph/infrastructure/pull/2939

Prevents accidental assignment to test agents

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/655
* [ ] All images have a valid tag and SHA256 sum
