### PR TITLE
Re-enable scheduling renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,17 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["config:base"],
-  "enabled": false,
-  "prHourlyLimit": 0,
+  "enabled": true,
+  "prHourlyLimit": 5,
   "masterIssue": true,
   "pinDigests": true,
   "baseBranches": ["master"],
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "packageRules": [
     {
       "groupName": "Sourcegraph Docker insiders images",


### PR DESCRIPTION
Renovate was disabled a while back [here](https://github.com/sourcegraph/deploy-sourcegraph/commit/95be861085c279ddf6e4e9b0945612a64bf57c44#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) in favor of renovate-downstream trigger the updates. Renovate-downstream was [removed in September](https://github.com/sourcegraph/sourcegraph/pull/25464) so we haven't been getting automatic updates since.

Once a week updates sounds reasonable to me but open to changing it up.