### PR TITLE
tests: use version of src that handles csrf removal moving point forward

### DIFF
--- a/tests/integration/restricted/install-src.sh
+++ b/tests/integration/restricted/install-src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-target_src_version="3.21.7"
+target_src_version="3.35.1"
 current_src_version=$(src version | grep -i current | sed 's/current version: //i')
 
 if [ "$current_src_version" != "$target_src_version" ]; then


### PR DESCRIPTION
<!-- description here -->
This (and its related changes) https://github.com/sourcegraph/sourcegraph/pull/28572 needed to be accommodated by `src`.  Version 3.35.1 of `src` does this. 


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
