### PR TITLE
Update test specific .tools-version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 golang 1.16
 yarn 1.22.4
 kubectl 1.21.7
-pulumi 1.12.0
+pulumi 1.14.1
 fd 7.4.0
 kustomize 4.0.5
 shfmt 3.1.0

--- a/tests/integration/fresh/step1/.tool-versions
+++ b/tests/integration/fresh/step1/.tool-versions
@@ -1,2 +1,3 @@
 yarn 1.22.4
-pulumi 1.12.0
+pulumi 1.14.1
+node 12.10.0

--- a/tests/integration/fresh/step1/.tool-versions
+++ b/tests/integration/fresh/step1/.tool-versions
@@ -1,3 +1,3 @@
 yarn 1.22.4
 pulumi 1.14.1
-node 12.10.0
+nodejs 12.10.0


### PR DESCRIPTION
This bumps pulumi to the latest 1.X version and adds node to the test test specific .tools-version. Possibly related issue that we faced: https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#132-2019-10-16

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
