### PR TITLE
migrator: add migrator job and require it to run

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -27,9 +27,36 @@ spec:
         app: sourcegraph-frontend
         deploy: sourcegraph
     spec:
+      initContainers:
+      - name: migrator
+        image: index.docker.io/sourcegraph/migrator:3.36.3@sha256:4339ced184eb228da06b5050da11794ea221f47be8a7ca24369a54a8cece923b
+        args: ["up"]
+        env:
+        - name: PGDATABASE
+          value: sg
+        - name: PGHOST
+          value: pgsql
+        - name: PGPORT
+          value: "5432"
+        - name: PGSSLMODE
+          value: disable
+        - name: PGUSER
+          value: sg
+        - name: CODEINSIGHTS_PGDATASOURCE
+          value: postgres://postgres:password@codeinsights-db:5432/postgres
+        - name: CODEINTEL_PGDATABASE
+          value: sg
+        - name: CODEINTEL_PGHOST
+          value: codeintel-db
+        - name: CODEINTEL_PGPORT
+          value: "5432"
+        - name: CODEINTEL_PGSSLMODE
+          value: disable
+        - name: CODEINTEL_PGUSER
+          value: sg
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:insiders@sha256:f6b962027b6cdb4a1cdea2573d9dfd89f353e2efb5ac2c485bf086bfa01e7a93
+        image: index.docker.io/sourcegraph/frontend:insiders@sha256:5b39d9736d201df9547391c86b08fa43ba4f500eac3c151d4dd253045aeded47
         args:
         - serve
         env:
@@ -105,7 +132,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:7f89e86a138d1f9a6967fb7ec04a1ea6464d1c417265445c8e5858e87616e012
+        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:75a3a365a89dc7377583df1e99b1955214d00dbf5d1e7d2626371733facdbcbd
         env:
           - name: POD_NAME
             valueFrom:

--- a/kubectl-apply-all.sh
+++ b/kubectl-apply-all.sh
@@ -12,5 +12,4 @@
 #
 # Apply the base Soucegraph deployment
 # shellcheck disable=SC2068
-
 kubectl apply --prune -l deploy=sourcegraph -f base --recursive $@

--- a/kubectl-apply-all.sh
+++ b/kubectl-apply-all.sh
@@ -12,4 +12,5 @@
 #
 # Apply the base Soucegraph deployment
 # shellcheck disable=SC2068
+
 kubectl apply --prune -l deploy=sourcegraph -f base --recursive $@

--- a/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
@@ -14,3 +14,4 @@ spec:
             name: cache-ssd
           securityContext:
             runAsUser: 0
+        - name: migrator

--- a/overlays/non-privileged/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/non-privileged/frontend/sourcegraph-frontend.Deployment.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: migrator
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 100
+            runAsGroup: 101
       containers:
       - name: frontend
         securityContext:


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/issues/25257 and https://github.com/sourcegraph/sourcegraph/issues/25256

This is the `migrator` job for the generic customer use case where `pgsql`, `codeintel-db`, and `codeinsights-db` are all running in cluster. 