### PR TITLE
Run each live cluster test as a separate test for easier retries

### DIFF
--- a/.buildkite/integration-test.sh
+++ b/.buildkite/integration-test.sh
@@ -16,6 +16,8 @@ export BUILD_CREATOR
 GENERATED_BASE=$(mktemp -d)
 export GENERATED_BASE
 
+export TEST_K8S_VERSION=$1
+
 cleanup() {
   echo "--- Cleaning up test artifacts"
   rm -rf "${GENERATED_BASE}"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -38,38 +38,35 @@ steps:
   - label: ":pulumi: :k8s:"
     concurrency: 3
     concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh
+    command: .buildkite/integration-test.sh 1.19
     env:
       VERBOSE: "true"
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-      TEST_K8S_VERSION: "1.19"
     agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
     concurrency: 3
     concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh
+    command: .buildkite/integration-test.sh 1.20
     env:
       VERBOSE: "true"
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-      TEST_K8S_VERSION: "1.20"
     agents: { queue: standard }
 
-      #  - label: ":pulumi: :k8s:"
-      #    concurrency: 3
-      #    concurrency_group: deploy-sourcegraph/integration
-      #    command: .buildkite/integration-test.sh
-      #    env:
-      #      VERBOSE: "true"
-      #      # Can be set to true to help debug test results, but ensure that created resources
-      #      # are removed manually
-      #      NOCLEANUP: "false"
-      #      TEST_K8S_VERSION: "1.21"
-      #    agents: { queue: standard }
+  - label: ":pulumi: :k8s:"
+    concurrency: 3
+    concurrency_group: deploy-sourcegraph/integration
+    command: .buildkite/integration-test.sh 1.21
+    env:
+      VERBOSE: "true"
+      # Can be set to true to help debug test results, but ensure that created resources
+      # are removed manually
+      NOCLEANUP: "false"
+    agents: { queue: standard }
 
   - label: ":k8s:"
     concurrency: 3

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -44,7 +44,32 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
+      TEST_K8S_VERSION: "1.19"
     agents: { queue: standard }
+
+  - label: ":pulumi: :k8s:"
+    concurrency: 3
+    concurrency_group: deploy-sourcegraph/integration
+    command: .buildkite/integration-test.sh
+    env:
+      VERBOSE: "true"
+      # Can be set to true to help debug test results, but ensure that created resources
+      # are removed manually
+      NOCLEANUP: "false"
+      TEST_K8S_VERSION: "1.20"
+    agents: { queue: standard }
+
+      #  - label: ":pulumi: :k8s:"
+      #    concurrency: 3
+      #    concurrency_group: deploy-sourcegraph/integration
+      #    command: .buildkite/integration-test.sh
+      #    env:
+      #      VERBOSE: "true"
+      #      # Can be set to true to help debug test results, but ensure that created resources
+      #      # are removed manually
+      #      NOCLEANUP: "false"
+      #      TEST_K8S_VERSION: "1.21"
+      #    agents: { queue: standard }
 
   - label: ":k8s:"
     concurrency: 3

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -36,7 +36,7 @@ steps:
   - wait
 
   - label: ":pulumi: :k8s:"
-    concurrency: 3
+    concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
     command: .buildkite/integration-test.sh 1.19
     env:
@@ -47,7 +47,7 @@ steps:
     agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
-    concurrency: 3
+    concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
     command: .buildkite/integration-test.sh 1.20
     env:
@@ -58,7 +58,7 @@ steps:
     agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
-    concurrency: 3
+    concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
     command: .buildkite/integration-test.sh 1.21
     env:

--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -23,7 +23,8 @@ func TestFreshDeployment(t *testing.T) {
 	// Specify which k8s version to test against
 	k8sVersion, present := os.LookupEnv("TEST_K8S_VERSION")
 	if !present {
-		log.Fatal("$TEST_K8S_VERSION not specified")
+		t.Error("$TEST_K8S_VERSION not specified")
+		t.FailNow()
 	}
 
 	// Validate on specified kubernetes version

--- a/tests/integration/fresh/fresh_test.go
+++ b/tests/integration/fresh/fresh_test.go
@@ -20,34 +20,37 @@ func TestFreshDeployment(t *testing.T) {
 	// Configure if the test should clean up after itself - useful for debugging
 	noCleanup := os.Getenv("NOCLEANUP") == "true"
 
-	// Validate on various kubernetes versions
-	for _, k8sVersion := range []string{"1.19", "1.20", "1.21"} {
-		k8sVersion := k8sVersion
-		t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {
-			config, err := commonConfig()
-			if err != nil {
-				t.Errorf("failed to generate Pulumi test configuration: %s", err)
-				t.FailNow()
-			}
-			config["kubernetesVersionPrefix"] = k8sVersion
-
-			tester := integration.ProgramTestManualLifeCycle(t, &integration.ProgramTestOptions{
-				Dir: "step1",
-
-				Config:               config,
-				ExpectRefreshChanges: true,
-				Quick:                false,
-				Verbose:              testing.Verbose(),
-				SkipStackRemoval:     noCleanup,
-
-				ExtraRuntimeValidation: ValidateFrontendIsReachable,
-			})
-			if err := testLifecycle(t, tester, noCleanup); err != nil {
-				t.Errorf("failed to run test: %s", err)
-				t.FailNow()
-			}
-		})
+	// Specify which k8s version to test against
+	k8sVersion, present := os.LookupEnv("TEST_K8S_VERSION")
+	if !present {
+		log.Fatal("$TEST_K8S_VERSION not specified")
 	}
+
+	// Validate on specified kubernetes version
+	t.Run(fmt.Sprintf("GKE version %q", k8sVersion), func(t *testing.T) {
+		config, err := commonConfig()
+		if err != nil {
+			t.Errorf("failed to generate Pulumi test configuration: %s", err)
+			t.FailNow()
+		}
+		config["kubernetesVersionPrefix"] = k8sVersion
+
+		tester := integration.ProgramTestManualLifeCycle(t, &integration.ProgramTestOptions{
+			Dir: "step1",
+
+			Config:               config,
+			ExpectRefreshChanges: true,
+			Quick:                false,
+			Verbose:              testing.Verbose(),
+			SkipStackRemoval:     noCleanup,
+
+			ExtraRuntimeValidation: ValidateFrontendIsReachable,
+		})
+		if err := testLifecycle(t, tester, noCleanup); err != nil {
+			t.Errorf("failed to run test: %s", err)
+			t.FailNow()
+		}
+	})
 }
 
 func commonConfig() (map[string]string, error) {


### PR DESCRIPTION
The integration tests create real GKE clusters to perform validation against multiple Kubernetes versions. It's very common that one cluster will fail validation, while the others succeed. Retrying the test means we have to re-run validation against cluster versions that already passed, which is slow and risks a formerly-successful version failing.

This PR makes it so that we run each Kubernetes version as a separate buildkite step, so that each can be retried individually. It is a short-term answer to reduce the pain until we can put more investment into fixing the flakiness.

Better potential solutions long-term:
- Investigate and resolve the root causes of the flaky tests (debugging the causes has proven difficult)
- Stop using GKE clusters, use kind or similar lightweight Kubernetes options
- Journal test progress so that a retry only attempts failed tests
- Abandon modern technology and live in a tent in the forest

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
