### PR TITLE
Run update tag script against overlays

### DIFF
--- a/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
           - mountPath: /mnt/cache

--- a/overlays/migrate-to-nonprivileged/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/gitserver/gitserver.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /data/repos)\" -ne 100 ]]; then chown -R 100:101 /data/repos; fi"]
           volumeMounts:
             - mountPath: /data/repos

--- a/overlays/migrate-to-nonprivileged/grafana/grafana.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/grafana/grafana.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 472:472 /var/lib/grafana"]
           volumeMounts:
             - mountPath: /var/lib/grafana

--- a/overlays/migrate-to-nonprivileged/indexed-search/indexed-search.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/indexed-search/indexed-search.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
             - mountPath: /data

--- a/overlays/migrate-to-nonprivileged/minio/minio.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/minio/minio.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
           - mountPath: /data

--- a/overlays/migrate-to-nonprivileged/prometheus/prometheus.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/prometheus/prometheus.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 100:100 /prometheus"]
           volumeMounts:
             - mountPath: /prometheus

--- a/overlays/migrate-to-nonprivileged/redis/redis-cache.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/redis/redis-cache.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonprivileged/redis/redis-store.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/redis/redis-store.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonprivileged/searcher/searcher.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/searcher/searcher.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:b5716faa7c5d40542132176960ae2d5708a20a8dd5dcd1e63d41af4c27a1b0c4
+          image: index.docker.io/sourcegraph/alpine-3.12:3.36.2@sha256:a8daf8c1c95117cf32a49eac1179dcc785a9004f309e238d7742d72ad4b59aaf
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
             - mountPath: /mnt/cache

--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -8,3 +8,4 @@ cd "$root_dir"
 CONSTRAINT=$1
 
 go run ./tools/enforce-tags "$CONSTRAINT" base/
+go run ./tools/enforce-tags "$CONSTRAINT" overlays/


### PR DESCRIPTION
The `overlays/migrate-to-nonprivileged` overlays include an image reference, which is unique among the overlays. The `update-docker-tags.sh` was only running against `base` so these overlays were getting skipped during releases and always staying on an old version.

On the fence about whether to include the actual manifest changes here or just the script itself. [Renovate is currently broken](https://github.com/sourcegraph/sourcegraph/issues/29473) in this repo so the other image references are quite out of date. I can revert if preferred.

I don't think this is worth doing a patch for - no customer has mentioned this, and it's been broken for a long time. We can just fix it for going forward.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
