### PR TITLE
use stateless agents

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,37 +1,37 @@
 steps:
   - label: ":k8s:"
     command: .buildkite/verify-yaml.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":k8s:"
     command: .buildkite/verify-label.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":k8s:"
     command: .buildkite/verify-rbac-labels.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ':lipstick:'
     command: .buildkite/prettier-check.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ':lipstick:'
     command: .buildkite/shfmt.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":k8s: :sleuth_or_spy:" 
     command: .buildkite/check-image-names.sh
-    agents: { queue: standard }
+    agents: { queue: job }
 
    # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/
   - command: .buildkite/ci-checkov.sh
     label: ':lock: security - checkov' 
-    agents: { queue: "standard" }
+    agents: { queue: "job" }
 
   - wait
 
@@ -44,7 +44,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":pulumi: :k8s:"
     concurrency: 6
@@ -55,7 +55,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":pulumi: :k8s:"
     concurrency: 6
@@ -66,7 +66,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: standard }
+    agents: { queue: job }
 
   - label: ":k8s:"
     concurrency: 3
@@ -76,4 +76,4 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: standard }
+    agents: { queue: job }


### PR DESCRIPTION
migrate to stateless agents. This will stop the rogue python issue we occasionally see. 