### PR TITLE
Bump sourcegraph/update-docker-tags to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pulumi/pulumi v1.12.0
 	github.com/sethgrid/pester v1.1.0
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220208010905-d160df06b91c
-	github.com/sourcegraph/update-docker-tags v0.9.0
+	github.com/sourcegraph/update-docker-tags v0.10.0
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect

--- a/go.sum
+++ b/go.sum
@@ -487,6 +487,8 @@ github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-2022020801090
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220208010905-d160df06b91c/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/update-docker-tags v0.9.0 h1:FeqPS1GH5n4KyTha/SpZvDDmrdS4c+N8cQ3xb4Rlb+A=
 github.com/sourcegraph/update-docker-tags v0.9.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
+github.com/sourcegraph/update-docker-tags v0.10.0 h1:KpY1HtvSt0FzDM/sR0jQF5StNbiPKpqmHhE0jpBEa0A=
+github.com/sourcegraph/update-docker-tags v0.10.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=


### PR DESCRIPTION
https://github.com/sourcegraph/update-docker-tags/releases/tag/v0.10.0

[_Created by Sourcegraph batch change `sourcegraph/bump-update-docker-tags-v0.10.0`._](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes/bump-update-docker-tags-v0.10.0)