### PR TITLE
Include migrator job in release batch change

### DIFF
--- a/configure/migrator/migrator.Job.yaml
+++ b/configure/migrator/migrator.Job.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: migrator
-        image: "index.docker.io/sourcegraph/migrator:3.36.3@sha256:4339ced184eb228da06b5050da11794ea221f47be8a7ca24369a54a8cece923b"
+        image: "index.docker.io/sourcegraph/migrator:3.37.0@sha256:404df69cfee90eaa9a3ab8b540a2d9affd22605caa5326a8ac4ba016e1d6d815"
         args: ["up"]
         env:
           - name: PGHOST

--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -9,3 +9,4 @@ CONSTRAINT=$1
 
 go run ./tools/enforce-tags "$CONSTRAINT" base/
 go run ./tools/enforce-tags "$CONSTRAINT" overlays/
+go run ./tools/enforce-tags "$CONSTRAINT" configure/


### PR DESCRIPTION
The configure/migrator job isn't picked up by the release automation. We'll probably switch away from this to `sg ops` commands soon but in the meantime this change will work.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
