### PR TITLE
Update restricted integration tests to clean up abandoned PVC’s

### DIFF
--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -38,7 +38,7 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE
 # Configure if the test should clean up after itself - useful for debugging
 if [ "${NOCLEANUP:-}" != "true" ]; then
   CLUSTER_CLEANUP="gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
-  DISK_CLEANUP="gcloud compute disks delete $(gcloud compute disks list --format="table(name,users)" --filter="name~^gke-${CLUSTER_NAME_PREFIX}.*-pvc-.* AND -users:*" --project ${TEST_GCP_PROJECT}) --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
+  DISK_CLEANUP="gcloud compute disks delete $(gcloud compute disks list --format="value(name)" --filter="name~^gke-${CLUSTER_NAME_PREFIX}.*-pvc-.* AND -users:*" --project ${TEST_GCP_PROJECT}) --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
   CLEANUP="$CLUSTER_CLEANUP; $DISK_CLEANUP; $CLEANUP"
 fi
 
@@ -49,7 +49,7 @@ kubectl apply -f nonroot-policy.yaml
 kubectl create namespace ns-sourcegraph
 
 # Deleting the namespace during cleanup is a cheap way to delete associated PVC's - see https://issuetracker.google.com/issues/121034250?pli=1
-CLEANUP="kubectl delete namespace ns-sourcegraph --timeout=60; $CLEANUP"
+CLEANUP="kubectl delete namespace ns-sourcegraph --timeout=60s; $CLEANUP"
 
 kubectl create serviceaccount -n ns-sourcegraph fake-user
 

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -17,8 +17,7 @@ CLEANUP=""
 trap 'bash -c "$CLEANUP"' EXIT
 
 CLUSTER_NAME_SUFFIX=$(echo ${BUILD_UUID} | head -c 8)
-CLUSTER_NAME_PREFIX="ds-test-restricted"
-CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-${CLUSTER_NAME_SUFFIX}"
+CLUSTER_NAME="ds-test-restricted-${CLUSTER_NAME_SUFFIX}"
 # get the STABLE channel version from GKE
 CLUSTER_VERSION=$(gcloud container get-server-config --zone us-central1-a -q 2>&1 | grep "defaultClusterVersion" | awk '{ print $2}')
 
@@ -38,8 +37,7 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE
 # Configure if the test should clean up after itself - useful for debugging
 if [ "${NOCLEANUP:-}" != "true" ]; then
   CLUSTER_CLEANUP="gcloud container clusters delete ${CLUSTER_NAME} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
-  DISK_CLEANUP="gcloud compute disks delete $(gcloud compute disks list --format="value(name)" --filter="name~^gke-${CLUSTER_NAME_PREFIX}.*-pvc-.* AND -users:*" --project ${TEST_GCP_PROJECT}) --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet"
-  CLEANUP="$CLUSTER_CLEANUP; $DISK_CLEANUP; $CLEANUP"
+  CLEANUP="$CLUSTER_CLEANUP; $CLEANUP"
 fi
 
 kubectl apply -f sourcegraph.StorageClass.yaml


### PR DESCRIPTION
Partially addresses https://github.com/sourcegraph/sourcegraph/issues/31262 by eliminating the main culprit.

When running restricted tests, we delete the cluster without deleting the resources first, which causes abandoned PVC's. Some days we generate hundreds of PVC's (I cleared out the disks from CI on Monday morning, and today there are 205 new ones). This test is the only one that behaves this way.

The abandoned-disks issue seems to be a common complaint without any real solution - the [official bug report](https://issuetracker.google.com/issues/121034250?pli=1) recommends deleting the namespace first, but that won't always fix it. As a workaround, I've added both the namespace deletion ~~and a step to try to delete abandoned disks through gcloud.~~ (removed this action because it doesn't belong in a test)

This is an incomplete fix since it only catches disks created through this test; a separate followup will be to add monitoring across all our projects to find abandoned disks.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum
