### PR TITLE
refactor postgres reference

### DIFF
--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
             memory: "50Mi"
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12-alpine:latest
+        image: index.docker.io/sourcegraph/postgres-12-alpine:135107_2022-03-03_9498a8bd3366@sha256:e26b159dc7c0c47d136886390c899816e669a3c2c1ead689bdad0b610364e45e
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -43,7 +43,7 @@ spec:
             memory: "50Mi"
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-12.6-alpine:insiders@sha256:8d6722e559ca813c91d575c818429b1a9b7f483cdeae652a4451b248a044a2ba
+        image: index.docker.io/sourcegraph/postgres-12-alpine:latest
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:


### PR DESCRIPTION
Our latest postgres-12-alpine image is quite old.  I assume this will be replaced as we create these new images in sourcegraph/sourcegraph pipeline.

<!-- description here -->

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [X ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [X ] [K8s Upgrade notes updated]: No note required, image update only
* [X ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/774) change.

* [X ] All images have a valid tag and SHA256 sum.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Image has already been tested locally.