### PR TITLE
Add resource limits to migrator container

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -31,6 +31,13 @@ spec:
       - name: migrator
         image: index.docker.io/sourcegraph/migrator:3.36.3@sha256:4339ced184eb228da06b5050da11794ea221f47be8a7ca24369a54a8cece923b
         args: ["up"]
+        resources:
+          limits:
+            cpu: 500m
+            memory: 100M
+          requests:
+            cpu: 100m
+            memory: 50M
         env:
         - name: PGDATABASE
           value: sg

--- a/configure/migrator/migrator.Job.yaml
+++ b/configure/migrator/migrator.Job.yaml
@@ -57,5 +57,12 @@ spec:
             value: "postgres"
           - name: CODEINSIGHTS_PGSSLMODE
             value: "disable"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 100M
+          requests:
+            cpu: 100m
+            memory: 50M
       restartPolicy: OnFailure
   backoffLimit: 4


### PR DESCRIPTION
Set some default resource limits on the migrator container. Partially addresses https://github.com/sourcegraph/sourcegraph/issues/32272.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/775) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

Deployed to a local test cluster and confirmed the migrator ran successfully. Ran `docker stats` while deploying a migrator locally to confirm the numbers looked ok (never got above 7 MB and 7% CPU of one core).