### PR TITLE
Revert "use stateless agents"

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,37 +1,37 @@
 steps:
   - label: ":k8s:"
     command: .buildkite/verify-yaml.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-label.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-rbac-labels.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ':lipstick:'
     command: .buildkite/prettier-check.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ':lipstick:'
     command: .buildkite/shfmt.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":git: :sleuth_or_spy:"
     command: .buildkite/verify-release/verify-release.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":k8s: :sleuth_or_spy:" 
     command: .buildkite/check-image-names.sh
-    agents: { queue: job }
+    agents: { queue: standard }
 
    # This runs the Checkov Terraform Code scanner
   # https://www.checkov.io/
   - command: .buildkite/ci-checkov.sh
     label: ':lock: security - checkov' 
-    agents: { queue: "job" }
+    agents: { queue: "standard" }
 
   - wait
 
@@ -44,7 +44,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
     concurrency: 6
@@ -55,7 +55,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
     concurrency: 6
@@ -66,7 +66,7 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: job }
+    agents: { queue: standard }
 
   - label: ":k8s:"
     concurrency: 3
@@ -76,4 +76,4 @@ steps:
       # Can be set to true to help debug test results, but ensure that created resources
       # are removed manually
       NOCLEANUP: "false"
-    agents: { queue: job }
+    agents: { queue: standard }


### PR DESCRIPTION
Reverts sourcegraph/deploy-sourcegraph#4080

## Test Plan 

- CI build with no hanging agents