### PR TITLE
Update Code Insights to use postgres

### DIFF
--- a/base/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/base/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    description: Configuration for TimescaleDB
+    description: Configuration for CodeInsightsDB
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
@@ -10,13 +10,6 @@ metadata:
   name: codeinsights-db-conf
 data:
   postgresql.conf: |
-    # --------------------------------------------------------------------------
-    # IMPORTANT: This is a TimescaleDB configuration file, not vanilla Postgres.
-    # Consider reading https://docs.timescale.com/latest/getting-started/configuring
-    # or running the 'timescaledb-tune' command from within the container to update
-    # your configuration file instead of making edits otherwise.
-    # --------------------------------------------------------------------------
-    #
     # -----------------------------
     # PostgreSQL configuration file
     # -----------------------------
@@ -692,7 +685,7 @@ data:
 
     # - Shared Library Preloading -
 
-    shared_preload_libraries = 'timescaledb'        # (change requires restart)
+    shared_preload_libraries = ''        # (change requires restart)
     #local_preload_libraries = ''
     #session_preload_libraries = ''
     #jit_provider = 'llvmjit'                # JIT library to use
@@ -767,7 +760,3 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
-    timescaledb.telemetry_level=basic
-    timescaledb.max_background_workers = 8
-    timescaledb.last_tuned = '2021-02-16T03:10:41Z'
-    timescaledb.last_tuned_version = '0.10.0'

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    description: Code Insights TimescaleDB instance.
+    description: Code Insights Postgres DB instance.
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
@@ -25,11 +25,15 @@ spec:
         group: backend
     spec:
       containers:
-      - name: timescaledb
-        image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:7d45a8e25d3df823dd5ae6faa087a9d3432f84d2c103929cbf401d0e35b3baa5
+      - name: codeinsights
+        image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:9aadfeff9139933a078042e65f046d22d6d2cdabac3e4e7cd7ce7e7ae1aa61c0
         env:
+        - name: POSTGRES_DB
+          value: postgres
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password
+        - name: POSTGRES_USER
+          value: postgres
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         - name: POSTGRESQL_CONF_DIR
@@ -37,7 +41,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 5432
-          name: timescaledb
+          name: codeinsights-db
         resources:
           limits:
             cpu: "4"
@@ -49,7 +53,22 @@ spec:
         - mountPath: /var/lib/postgresql/data/
           name: disk
         - mountPath: /conf
-          name: timescaledb-conf
+          name: codeinsights-conf
+      - name: codeinsights-exporter
+        image: index.docker.io/sourcegraph/postgres_exporter:insiders@sha256:50b1d8b7b71bb7eca9bf53098b1b159d3d400f5aa95751dd62d96a07f460996a
+        env:
+        - name: DATA_SOURCE_NAME
+          value: postgres://postgres:password@localhost:5432/?sslmode=disable
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /config/code_insights_queries.yaml
+        terminationMessagePolicy: FallbackToLogsOnError
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi
       terminationGracePeriodSeconds: 120
       securityContext:
         runAsUser: 0
@@ -57,7 +76,7 @@ spec:
       - name: disk
         persistentVolumeClaim:
           claimName: codeinsights-db
-      - name: timescaledb-conf
+      - name: codeinsights-conf
         configMap:
           defaultMode: 0777
           name: codeinsights-db-conf

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -54,7 +54,7 @@ spec:
           name: disk
         - mountPath: /conf
           name: codeinsights-conf
-      - name: codeinsights-exporter
+      - name: pgsql-exporter
         image: index.docker.io/sourcegraph/postgres_exporter:insiders@sha256:50b1d8b7b71bb7eca9bf53098b1b159d3d400f5aa95751dd62d96a07f460996a
         env:
         - name: DATA_SOURCE_NAME

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -58,7 +58,7 @@ spec:
         image: index.docker.io/sourcegraph/postgres_exporter:insiders@sha256:50b1d8b7b71bb7eca9bf53098b1b159d3d400f5aa95751dd62d96a07f460996a
         env:
         - name: DATA_SOURCE_NAME
-          value: postgres://postgres:password@localhost:5432/?sslmode=disable
+          value: postgres://postgres:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/code_insights_queries.yaml
         terminationMessagePolicy: FallbackToLogsOnError

--- a/base/codeinsights-db/codeinsights-db.Service.yaml
+++ b/base/codeinsights-db/codeinsights-db.Service.yaml
@@ -12,9 +12,9 @@ metadata:
   name: codeinsights-db
 spec:
   ports:
-  - name: timescaledb
+  - name: codeinsights-db
     port: 5432
-    targetPort: timescaledb
+    targetPort: codeinsights-db
   selector:
     app: codeinsights-db
   type: ClusterIP

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -109,7 +109,7 @@ patches:
     name: codeinsights-db
     group: apps
     version: v1
-  path: delete-resources.yaml  
+  path: delete-resources-2.yaml  
 - target:
     kind: Deployment
     name: minio
@@ -214,7 +214,7 @@ patches:
       template:
         spec:
           containers:
-          - name: timescaledb
+          - name: codeinsights
             env:
             - name: POD_NAME
               valueFrom:
@@ -223,7 +223,7 @@ patches:
                   fieldPath: metadata.name
             volumeMounts:
             - mountPath: /conf
-              name: timescaledb-conf
+              name: codeinsights-conf
             - mountPath: /var/lib/postgresql/data/
               name: disk
               subPathExpr: $(POD_NAME)
@@ -233,7 +233,7 @@ patches:
               path: /mnt/disks/ssd0/buildkite/cluster-deployments/
               type: DirectoryOrCreate
             persistentVolumeClaim: null              
-          - name: timescaledb-conf
+          - name: codeinsights-conf
             configMap:
               defaultMode: 0777
               name: codeinsights-db-conf

--- a/overlays/minikube/kustomization.yaml
+++ b/overlays/minikube/kustomization.yaml
@@ -104,13 +104,13 @@ patches:
       name: codeintel-db
       group: apps
       version: v1
-    path: delete-resources-2.yaml    
+    path: delete-resources-2.yaml
   - target:
       kind: Deployment
       name: codeinsights-db
       group: apps
       version: v1
-    path: delete-resources.yaml  
+    path: delete-resources-2.yaml
   - target:
       kind: Deployment
       name: minio

--- a/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: timescaledb
+        - name: codeinsights
           securityContext:
             # Required to prevent escalations to root, postgres runs as this user
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Update the code insights deployment to support running a postgres image. Adds postgres exporter to collect metrics and removes the timescale references.

Depends on https://github.com/sourcegraph/sourcegraph/pull/32616. Part of https://github.com/sourcegraph/sourcegraph/issues/32075.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated - will do once all changes are ready
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md) - will add
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/780
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
* [X] Base installation of 3.37 + upgrade to this change
* [X] Base installation of this change
* [X] Confirmed changes in low-resource and minikube overlays
* [X] Installation of 3.37 using the non-privileged-create-cluster overlay + upgrade to this change using the non-privileged overlay
* [X] Installation of this change using the non-privileged-create-cluster overlay