### PR TITLE
Support running codeinsights as postgres or timescale

### DIFF
--- a/base/codeinsights-db/codeinsights-db.ConfigMap.yaml
+++ b/base/codeinsights-db/codeinsights-db.ConfigMap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    description: Configuration for TimescaleDB
+    description: Configuration for CodeInsightsDB
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
@@ -10,13 +10,6 @@ metadata:
   name: codeinsights-db-conf
 data:
   postgresql.conf: |
-    # --------------------------------------------------------------------------
-    # IMPORTANT: This is a TimescaleDB configuration file, not vanilla Postgres.
-    # Consider reading https://docs.timescale.com/latest/getting-started/configuring
-    # or running the 'timescaledb-tune' command from within the container to update
-    # your configuration file instead of making edits otherwise.
-    # --------------------------------------------------------------------------
-    #
     # -----------------------------
     # PostgreSQL configuration file
     # -----------------------------
@@ -692,7 +685,7 @@ data:
 
     # - Shared Library Preloading -
 
-    shared_preload_libraries = 'timescaledb'        # (change requires restart)
+    shared_preload_libraries = ''        # (change requires restart)
     #local_preload_libraries = ''
     #session_preload_libraries = ''
     #jit_provider = 'llvmjit'                # JIT library to use
@@ -767,7 +760,3 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
-    timescaledb.telemetry_level=basic
-    timescaledb.max_background_workers = 8
-    timescaledb.last_tuned = '2021-02-16T03:10:41Z'
-    timescaledb.last_tuned_version = '0.10.0'

--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    description: Code Insights TimescaleDB instance.
+    description: Code Insights Postgres DB instance.
   labels:
     app.kubernetes.io/component: codeinsights-db
     deploy: sourcegraph
@@ -25,11 +25,15 @@ spec:
         group: backend
     spec:
       containers:
-      - name: timescaledb
+      - name: codeinsights
         image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:7d45a8e25d3df823dd5ae6faa087a9d3432f84d2c103929cbf401d0e35b3baa5
         env:
+        - name: POSTGRES_DB
+          value: postgres
         - name: POSTGRES_PASSWORD # Accessible by Sourcegraph applications on the network only, so password auth is not used.
           value: password
+        - name: POSTGRES_USER
+          value: postgres
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         - name: POSTGRESQL_CONF_DIR
@@ -37,7 +41,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         ports:
         - containerPort: 5432
-          name: timescaledb
+          name: codeinsights-db
         resources:
           limits:
             cpu: "4"
@@ -49,7 +53,7 @@ spec:
         - mountPath: /var/lib/postgresql/data/
           name: disk
         - mountPath: /conf
-          name: timescaledb-conf
+          name: codeinsights-conf
       terminationGracePeriodSeconds: 120
       securityContext:
         runAsUser: 0
@@ -57,7 +61,7 @@ spec:
       - name: disk
         persistentVolumeClaim:
           claimName: codeinsights-db
-      - name: timescaledb-conf
+      - name: codeinsights-conf
         configMap:
           defaultMode: 0777
           name: codeinsights-db-conf

--- a/base/codeinsights-db/codeinsights-db.Service.yaml
+++ b/base/codeinsights-db/codeinsights-db.Service.yaml
@@ -12,9 +12,9 @@ metadata:
   name: codeinsights-db
 spec:
   ports:
-  - name: timescaledb
+  - name: codeinsights-db
     port: 5432
-    targetPort: timescaledb
+    targetPort: codeinsights-db
   selector:
     app: codeinsights-db
   type: ClusterIP

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -214,7 +214,7 @@ patches:
       template:
         spec:
           containers:
-          - name: timescaledb
+          - name: codeinsights
             env:
             - name: POD_NAME
               valueFrom:
@@ -223,7 +223,7 @@ patches:
                   fieldPath: metadata.name
             volumeMounts:
             - mountPath: /conf
-              name: timescaledb-conf
+              name: codeinsights-conf
             - mountPath: /var/lib/postgresql/data/
               name: disk
               subPathExpr: $(POD_NAME)
@@ -233,7 +233,7 @@ patches:
               path: /mnt/disks/ssd0/buildkite/cluster-deployments/
               type: DirectoryOrCreate
             persistentVolumeClaim: null              
-          - name: timescaledb-conf
+          - name: codeinsights-conf
             configMap:
               defaultMode: 0777
               name: codeinsights-db-conf

--- a/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: timescaledb
+        - name: codeinsights
           securityContext:
             # Required to prevent escalations to root, postgres runs as this user
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Partial re-implementation of https://github.com/sourcegraph/deploy-sourcegraph/pull/4099. The biggest change is that this PR does not include adding the postgres exporter.

Without the postgres exporter, this configuration makes it possible to run the codeinsights db using either a timescale-based or postgres-based image. It also unblocks CI tests on https://github.com/sourcegraph/sourcegraph/pull/32697.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
- [X] Deployed a 3.37 release, then upgraded to this configuration running a timescale-based image
- [X] Deployed a 3.37 release, then upgraded to this configuration running a postgres-based image
- [X] CI tests cover new installations