### PR TITLE
Remove the Checkov step from the Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -27,12 +27,6 @@ steps:
     command: .buildkite/check-image-names.sh
     agents: { queue: job }
 
-   # This runs the Checkov Terraform Code scanner
-  # https://www.checkov.io/
-  - command: .buildkite/ci-checkov.sh
-    label: ':lock: security - checkov' 
-    agents: { queue: "job" }
-
   - wait
 
   - label: ":pulumi: :k8s:"


### PR DESCRIPTION
Until we can move to using a pinned Checkov image version – the lack of image
pinning is causing the build step to break unpredictably.

### Checklist

The below checks don't apply as this only changes the build pipeline, not functionality.

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

Confirm that the build step in question doesn't occur.
