### PR TITLE
use bash source as run directory

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -xeu
 cd $BUILDKITE_BUILD_CHECKOUT_PATH
 
 echo "Installing asdf dependencies as defined in '$BUILDKITE_BUILD_CHECKOUT_PATH/.tool-versions':"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 set -xeu
-pushd $BUILDKITE_BUILD_CHECKOUT_PATH
+pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 echo "Installing asdf dependencies as defined in '$BUILDKITE_BUILD_CHECKOUT_PATH/.tool-versions':"
 asdf install
-
-popd

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xeu
+set -eu
 pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 echo "Installing asdf dependencies as defined in '$BUILDKITE_BUILD_CHECKOUT_PATH/.tool-versions':"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 set -xeu
-cd $BUILDKITE_BUILD_CHECKOUT_PATH
+pushd $BUILDKITE_BUILD_CHECKOUT_PATH
 
 echo "Installing asdf dependencies as defined in '$BUILDKITE_BUILD_CHECKOUT_PATH/.tool-versions':"
 asdf install
+
+popd


### PR DESCRIPTION
Fixes the following error, where there does not appear to be any code checked out in the `BUILDKITE_BUILD_CHECKOUT_PATH`


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->
* [ ] Sister [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) change:
* [ ] All images have a valid tag and SHA256 sum
### Test plan

A green build on this PR
