### PR TITLE
Add init container to codeinsights-db to fix data dir permissions

### DIFF
--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -24,6 +24,22 @@ spec:
         app: codeinsights-db
         group: backend
     spec:
+      initContainers:
+      - name: correct-data-dir-permissions
+        image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:3d926ffec4cdd54b5197bf16dded63e37b1a7045e2623ae9f8eda0a63bbf8231
+        command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data/
+          name: disk
+        securityContext:
+          runAsUser: 0
+        resources:
+          limits:
+            cpu: "10m"
+            memory: "50Mi"
+          requests:
+            cpu: "10m"
+            memory: "50Mi"
       containers:
       - name: codeinsights
         image: index.docker.io/sourcegraph/codeinsights-db:insiders@sha256:290959786a7186109241cc0437fadb23bb36200ab2016079439d77d353c2ffca

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -109,7 +109,7 @@ patches:
     name: codeinsights-db
     group: apps
     version: v1
-  path: delete-resources.yaml  
+  path: delete-resources-2.yaml  
 - target:
     kind: Deployment
     name: minio

--- a/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/overlays/non-privileged/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: correct-data-dir-permissions
+          securityContext:
+            # Required to prevent escalations to root.
+            allowPrivilegeEscalation: false
+            runAsUser: 70
+            runAsGroup: 70
       containers:
         - name: codeinsights
           securityContext:
@@ -14,4 +21,4 @@ spec:
             runAsGroup: 70
       securityContext:
         # Required to prevent escalations to root, postgres runs as this user
-        runAsUser: 70 
+        runAsUser: 70


### PR DESCRIPTION
Added the same initContainer that is present for codeintel-db and pgsql to the codeinsights-db deployment.

## Context

When migrating from timescale to postgres on the non-privileged overlay in a GKE cluster, the following error shows up:

```
codeinsights-db-59fddf6dbf-wlgfs codeinsights waiting for server to start....2022-04-12 18:52:50.561 UTC [16] FATAL:  data directory "/var/lib/postgresql/data/pgdata" has invalid permissions
```

And it's true! That directory has the following permissions set at startup (before postgres starts), even on the timescale docker image:
```
Access: (2770/drwxrws---)  Uid: (   70/postgres)   Gid: (   70/postgres)
```

By the time postgres starts, the permissions are rewritten to be correct:
```
Access: (0700/drwx------)  Uid: (   70/postgres)   Gid: (   70/postgres)
```

This error doesn't happen when upgrading the base deployment, or when starting a new non-privileged deployment. Strangely, I also can't make it happen in my `kind` cluster - only when running against a GKE cluster. We also saw this behavior when switching dogfood to helm, although I can't remember if it was also using the new postgres image.

I haven't been able to track down why the behavior is different between the timescale image and postgres, or why it's only a factor in GKE. I figure it's safer to just go ahead and run the initContainer to be consistent with the other databases, and we can dig in more fully later on.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Upgrade from 3.38 to latest, using the restricted overlay. Code insights does not start before this change; starts successfully afterwards and $PGDATA ends up the the `0700` permissions (so some kind of permission rewriting is happening during the postgres startup).