### PR TITLE
add patch for db's with init containers

### DIFF
--- a/overlays/low-resource/delete-resources-3.yaml
+++ b/overlays/low-resource/delete-resources-3.yaml
@@ -1,0 +1,4 @@
+- op: remove
+  path: /spec/template/spec/initContainers/0/resources
+- op: remove
+  path: /spec/template/spec/containers/0/resources

--- a/overlays/low-resource/delete-resources-4.yaml
+++ b/overlays/low-resource/delete-resources-4.yaml
@@ -1,0 +1,6 @@
+- op: remove
+  path: /spec/template/spec/initContainers/0/resources
+- op: remove
+  path: /spec/template/spec/containers/0/resources
+- op: remove
+  path: /spec/template/spec/containers/1/resources

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -55,7 +55,7 @@ patches:
     name: pgsql
     group: apps
     version: v1
-  path: delete-resources-2.yaml
+  path: delete-resources-4.yaml
 - target:
     kind: Deployment
     name: prometheus
@@ -103,7 +103,7 @@ patches:
     name: codeintel-db
     group: apps
     version: v1
-  path: delete-resources-2.yaml    
+  path: delete-resources-4.yaml    
 - target:
     kind: Deployment
     name: codeinsights-db

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -109,7 +109,7 @@ patches:
     name: codeinsights-db
     group: apps
     version: v1
-  path: delete-resources-2.yaml  
+  path: delete-resources-3.yaml  
 - target:
     kind: Deployment
     name: minio


### PR DESCRIPTION
deletes resources for init containers and containers in dbs

fixes https://buildkite.com/sourcegraph/sourcegraph/builds/142219#ddac15fd-2ea4-4037-910e-7dfec6cc8629/365-367
### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

generated overlay locally
