### PR TITLE
tools: use env instead of hardcoding /bin/bash

### DIFF
--- a/tools/update-docker-tags.sh
+++ b/tools/update-docker-tags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
/bin/bash can be old. Additionally not all systems have /bin/bash, for
example on my NixOS box.

Test Plan: ran the script.