### PR TITLE
fix: make migrator flags consistent across deployments

### DIFF
--- a/configure/migrator/migrator.Job.yaml
+++ b/configure/migrator/migrator.Job.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: migrator
         image: "index.docker.io/sourcegraph/migrator:3.38.1@sha256:4bd4fd68fc3e6d1c947847aec126ff8c4577da80cbd11252c6c72a482722ad66"
-        args: ["up"]
+        args: ["up", "-db=all"]
         env:
           - name: PGHOST
             value: "pgsql"

--- a/configure/migrator/migrator.Job.yaml
+++ b/configure/migrator/migrator.Job.yaml
@@ -19,7 +19,9 @@ spec:
       containers:
       - name: migrator
         image: "index.docker.io/sourcegraph/migrator:3.38.1@sha256:4bd4fd68fc3e6d1c947847aec126ff8c4577da80cbd11252c6c72a482722ad66"
-        args: ["up", "-db=all"]
+        args:
+          - up
+          - -db=all
         env:
           - name: PGHOST
             value: "pgsql"


### PR DESCRIPTION
<!-- description here -->
A fix that corrects the default behavior of the `migrator` service is included in this release. An attempt to standardize CLI packages in v3.39.0 unintentionally broke the default behavior. In order to guard against this, all command line arguments are explicitly set in the deployment manifest.

https://github.com/sourcegraph/customer/issues/845

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [x] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [x] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
