### PR TITLE
fix: cadvisor can pickup oom events

### DIFF
--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -58,10 +58,15 @@ spec:
         - name: disk
           mountPath: /dev/disk
           readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
         ports:
         - name: http
           containerPort: 48080
           protocol: TCP
+        securityContext:
+          privileged: true
       automountServiceAccountToken: false
       terminationGracePeriodSeconds: 30
       volumes:
@@ -80,3 +85,6 @@ spec:
       - name: disk
         hostPath:
           path: /dev/disk
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg

--- a/overlays/non-privileged/cadvisor/cadvisor.DaemonSet.yaml
+++ b/overlays/non-privileged/cadvisor/cadvisor.DaemonSet.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cadvisor
+        volumeMounts:
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+          $patch: delete
+        securityContext:
+          privileged: null
+      volumes:
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+        $patch: delete

--- a/overlays/non-privileged/kustomization.yaml
+++ b/overlays/non-privileged/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - frontend/sourcegraph-frontend.RoleBinding.yaml
   - prometheus/prometheus.RoleBinding.yaml
 patchesStrategicMerge:
+  - cadvisor/cadvisor.DaemonSet.yaml
   - codeintel-db/codeintel-db.Deployment.yaml
   - codeinsights-db/codeinsights-db.Deployment.yaml
   - frontend/sourcegraph-frontend.Deployment.yaml


### PR DESCRIPTION
Follow up https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/804
Related: https://github.com/sourcegraph/sourcegraph/pull/35030

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

### OOM events

Tested on a GKE cluster

cadvisor did not complain about no `kmsg` device or operation not permitted
```sh
$ k logs -l app=cadvisor                                                                                                                                                                                                                                                                  18:15:22
W0506 01:14:46.029975       1 machine_libipmctl.go:63] There are no NVM devices!
W0506 01:14:46.274086       1 machine_libipmctl.go:63] There are no NVM devices!
```

Then follow the exact same test plan in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/121

### Non-privileged overlay

```sh
./overlay-generate-cluster.sh non-privileged generated-cluster
```

inspect `generated-cluster/apps_v1_daemonset_cadvisor.yaml`

no present of `privielged` and `/dev/kmsg` in volumes & volumeMounts