### PR TITLE
Update alpine-3.12 references to to use alpine-3.14 images

### DIFF
--- a/base/codeinsights-db/codeinsights-db.Deployment.yaml
+++ b/base/codeinsights-db/codeinsights-db.Deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
       - name: correct-data-dir-permissions
-        image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+        image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
         command: ["sh", "-c", "if [ -d /var/lib/postgresql/data/pgdata ]; then chmod 750 /var/lib/postgresql/data/pgdata; fi"]
         volumeMounts:
         - mountPath: /var/lib/postgresql/data/

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
       - name: correct-data-dir-permissions
-        image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+        image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
         command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
         volumeMounts:
         - mountPath: /data

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
       - name: correct-data-dir-permissions
-        image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+        image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
         command: ["sh", "-c", "if [ -d /data/pgdata-12 ]; then chmod 750 /data/pgdata-12; fi"]
         volumeMounts:
         - mountPath: /data

--- a/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/frontend/sourcegraph-frontend.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
           - mountPath: /mnt/cache

--- a/overlays/migrate-to-nonprivileged/gitserver/gitserver.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/gitserver/gitserver.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /data/repos)\" -ne 100 ]]; then chown -R 100:101 /data/repos; fi"]
           volumeMounts:
             - mountPath: /data/repos

--- a/overlays/migrate-to-nonprivileged/grafana/grafana.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/grafana/grafana.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 472:472 /var/lib/grafana"]
           volumeMounts:
             - mountPath: /var/lib/grafana

--- a/overlays/migrate-to-nonprivileged/indexed-search/indexed-search.StatefulSet.yaml
+++ b/overlays/migrate-to-nonprivileged/indexed-search/indexed-search.StatefulSet.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
             - mountPath: /data

--- a/overlays/migrate-to-nonprivileged/minio/minio.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/minio/minio.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 100:101 /data"]
           volumeMounts:
           - mountPath: /data

--- a/overlays/migrate-to-nonprivileged/prometheus/prometheus.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/prometheus/prometheus.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 100:100 /prometheus"]
           volumeMounts:
             - mountPath: /prometheus

--- a/overlays/migrate-to-nonprivileged/redis/redis-cache.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/redis/redis-cache.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonprivileged/redis/redis-store.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/redis/redis-store.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-file-ownership
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "chown -R 999:1000 /redis-data"]
           volumeMounts:
             - mountPath: /redis-data

--- a/overlays/migrate-to-nonprivileged/searcher/searcher.Deployment.yaml
+++ b/overlays/migrate-to-nonprivileged/searcher/searcher.Deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       initContainers:
         - name: transfer-cache
-          image: index.docker.io/sourcegraph/alpine-3.12:insiders@sha256:75b3a5e6f63a63313a9572d54cb459145956ef54c72df29863d2d03b1295ebec
+          image: index.docker.io/sourcegraph/alpine-3.14:insiders@sha256:06c6bcf2df49cad29ab9b8d2e0db3f5c9bf0d4365c2fc6d579c3e0fd4627dbe1
           command: ["sh", "-c", "if [[ \"$(stat -c '%u' /mnt/cache)\" -ne 100 ]]; then chown -R 100:101 /mnt/cache; fi"]
           volumeMounts:
             - mountPath: /mnt/cache


### PR DESCRIPTION
The alpine-3.12 image was removed in https://github.com/sourcegraph/sourcegraph/pull/34906 (as a followup to https://github.com/sourcegraph/sourcegraph/pull/34508). We have a few direct references to alpine-3.12 in the deployment manifests to run init commands, so these need to be updated.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [X] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: none needed
* [X] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Automated CI tests