### PR TITLE
Set reclaimPolicy to Delete on test storageclasses

### DIFF
--- a/tests/integration/fresh/step1/index.ts
+++ b/tests/integration/fresh/step1/index.ts
@@ -18,6 +18,8 @@ const storageClass = new k8s.storage.v1.StorageClass(
         },
         provisioner: 'kubernetes.io/gce-pd',
 
+        reclaimPolicy: 'Delete',
+
         parameters: {
             type: 'pd-ssd',
         },

--- a/tests/integration/restricted/sourcegraph.StorageClass.yaml
+++ b/tests/integration/restricted/sourcegraph.StorageClass.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sourcegraph
   labels:
     deploy: sourcegraph-storage
+reclaimPolicy: Delete
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-ssd # This configures SSDs (recommended).

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -47,7 +47,7 @@ kubectl apply -f nonroot-policy.yaml
 kubectl create namespace ns-sourcegraph
 
 # Deleting the namespace during cleanup is a cheap way to delete associated PVC's - see https://issuetracker.google.com/issues/121034250?pli=1
-CLEANUP="kubectl delete namespace ns-sourcegraph --timeout=60s; $CLEANUP"
+CLEANUP="kubectl delete namespace ns-sourcegraph --timeout=180s; $CLEANUP"
 
 kubectl create serviceaccount -n ns-sourcegraph fake-user
 


### PR DESCRIPTION
Although the default storageClass reclaimPolicy setting is Delete, we're seeing orphaned disks pile up again (https://github.com/sourcegraph/sourcegraph/issues/31262). I'm not sure this change will make a difference but figured it's worth a shot.

I've also increased the timeout for the namespace deletion, in case that was the culprit. I'm definitely just throwing darts here.

Long term fix is tracked in https://github.com/sourcegraph/sourcegraph/issues/32916.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
See if disks keep being orphaned in the CI project.