### PR TITLE
Delete orphaned disks during test cleanup

### DIFF
--- a/.buildkite/cleanup-disks.sh
+++ b/.buildkite/cleanup-disks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
+
+export TEST_GCP_PROJECT=sourcegraph-ci
+export TEST_GCP_ZONE=us-central1-a
+
+# Temporary fix: delete unattached disks associated with these tests
+# https://github.com/sourcegraph/sourcegraph/issues/32916 will implement long-term fix
+gcloud compute disks delete $(gcloud compute disks list --filter="name:gke-ds-test AND NOT users:*" --format="value(name)" --project ${TEST_GCP_PROJECT}) --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -75,3 +75,9 @@ steps:
       # are removed manually
       NOCLEANUP: "false"
     agents: { queue: standard }
+
+  - wait
+
+  - label: ":k8s:"
+    command: .buildkite/cleanup-disks.sh
+    agents: { queue: standard }


### PR DESCRIPTION
As expected, https://github.com/sourcegraph/deploy-sourcegraph/pull/4132 had no effect and we're still seeing orphaned disks. After discussion with DevOps we decided to just go ahead and remove the disks during the test run, until a longer-term solution is put in place.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Disks should be gone