### PR TITLE
Add a startup probe to codeintel-db

### DIFF
--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -54,6 +54,12 @@ spec:
           exec:
             command:
               - /liveness.sh
+        startupProbe:
+          exec:
+            command:
+              - /liveness.sh
+          failureThreshold: 360
+          periodSeconds: 10
         ports:
         - containerPort: 5432
           name: pgsql


### PR DESCRIPTION
Prior to this change, it was easy for `codeintel-db` to enter an infinite kill+restart loop in the event that Postgres had to recover database state from an OOM death. A customer ran into a situation where [Postgres took ~5 minutes to recover](https://sourcegraph.slack.com/archives/C02BQBNJVL0/p1654052484831609?thread_ts=1653959717.867999&cid=C02BQBNJVL0) with 11GB Rockskip tables.

After this change, Postgres will be given 1 hour to start. Is that enough time, or too long? It's a balance between:

- Reducing the likelihood customers get stuck and require manual intervention when Postgres is recovering with large tables (we have concrete evidence this happens, see above)
- Restarting Postgres quickly when there's some bad pod state lying around and a restart would fix it (hypothetical, seems relatively unlikely)

Ideally, the startup probe would know if Postgres is making progress, but I don't know how to easily teach it and for the check to be reliable.

### Checklist

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<details>
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: depl
spec:
  replicas: 1
  selector:
    matchLabels:
      component: web
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        component: web
    spec:
      terminationGracePeriodSeconds: 0
      containers:
        - name: foo
          image: python
          command: ["bash"]
          args: ["-c", "trap SIGTERM exit; while true; do echo >> /log; wc -c /log; sleep 1; done"]
          startupProbe:
            exec:
              command:
              - "python3"
              - "-c"
              - "from pathlib import Path; import sys; sys.exit(1 if len(Path('/log').read_bytes()) < 5 else 0)"
            failureThreshold: 10
            periodSeconds: 1
          livenessProbe:
            exec:
              command:
              - "false"
            failureThreshold: 3
            periodSeconds: 1
```
</details>

- `kubectl apply -f deployment.yaml`
- Wait 5s, startup probe succeeds, container is up
- Wait 3s, liveness probe fails, k8s kills container