### PR TITLE
buildkite: fix cleanup-disks.sh

### DIFF
--- a/.buildkite/cleanup-disks.sh
+++ b/.buildkite/cleanup-disks.sh
@@ -9,4 +9,5 @@ export TEST_GCP_ZONE=us-central1-a
 
 # Temporary fix: delete unattached disks associated with these tests
 # https://github.com/sourcegraph/sourcegraph/issues/32916 will implement long-term fix
-gcloud compute disks delete $(gcloud compute disks list --filter="name:gke-ds-test AND NOT users:*" --format="value(name)" --project ${TEST_GCP_PROJECT}) --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet
+gcloud compute disks list --filter="name:gke-ds-test AND NOT users:*" --format="value(name)" --project ${TEST_GCP_PROJECT} |
+  while read -r disk; do gcloud compute disks delete ${disk} --zone ${TEST_GCP_ZONE} --project ${TEST_GCP_PROJECT} --quiet; done


### PR DESCRIPTION
This isn't really a failure, but should prevent failures if no disks are listed

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

disk cleanup step should pass
