### PR TITLE
Disable integration test against 1.19

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -33,16 +33,18 @@ steps:
 
   - wait
 
-  - label: ":pulumi: :k8s:"
-    concurrency: 6
-    concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh 1.19
-    env:
-      VERBOSE: "true"
-      # Can be set to true to help debug test results, but ensure that created resources
-      # are removed manually
-      NOCLEANUP: "false"
-    agents: { queue: standard }
+  # GKE already drops support for 1.19 hence this test will not run
+  # https://cloud.google.com/kubernetes-engine/docs/release-notes#June_30_2022
+  # - label: ":pulumi: :k8s:"
+  #   concurrency: 6
+  #   concurrency_group: deploy-sourcegraph/integration
+  #   command: .buildkite/integration-test.sh 1.19
+  #   env:
+  #     VERBOSE: "true"
+  #     # Can be set to true to help debug test results, but ensure that created resources
+  #     # are removed manually
+  #     NOCLEANUP: "false"
+  #   agents: { queue: standard }
 
   - label: ":pulumi: :k8s:"
     concurrency: 6


### PR DESCRIPTION
[<!-- description here -->](https://buildkite.com/sourcegraph/deploy-sourcegraph/builds/26441#0182173b-bed2-49a7-86e9-6d6516e25fa2
https://cloud.google.com/kubernetes-engine/docs/release-notes#June_30_2022

```
[                          step1 ] Diagnostics:
[                          step1 ]   gcp:container:Cluster (ds-integ-fresh-test-cluster):
[                          step1 ]     error: googleapi: Error 400: Master version "1.19.16-gke.15700" is unsupported., badRequest
```

apparently, GKE no longer supports 1.19 since June 30)

in the future, we can consider using `kind` to validate the deployment

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->


CI passes