### PR TITLE
Update storage spec for statefulset in minikube overlay

### DIFF
--- a/overlays/minikube/README.md
+++ b/overlays/minikube/README.md
@@ -1,6 +1,16 @@
 This kustomization deletes resource declarations and storage classnames to enable runnning Sourcegraph on minikube.
 
-Starting Sourcegraph:
+## Prerequisite
+
+- [minikube](https://minikube.sigs.k8s.io/docs/start/)
+
+## Configuration
+
+The Sourcegraph minikube instance requires ~100Gi of free disk space by default (10Gi for each persistentvolumeclaim, 47Gi for all statefulsets etc).
+
+If you wish to lower the disk space requirement, you may adjust the storage values for the PersistentVolumeClaim, gitserver StatefulSet, and indexed-search StatefulSet in the `kustomization.yaml` file accordingly.
+
+## Starting Sourcegraph
 
 To use it, execute the following command from the root directory of this repository:
 
@@ -18,7 +28,7 @@ kubectl -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort
 minikube service list
 ``` 
 
-Tearing it down:
+## Tearing it down
 
 ```shell script
 kubectl delete namespaces ns-sourcegraph

--- a/overlays/minikube/kustomization.yaml
+++ b/overlays/minikube/kustomization.yaml
@@ -125,9 +125,24 @@ patches:
         # This is the default storage class for minikube
         value: standard
   - target:
+      kind: PersistentVolumeClaim
+    patch: |-
+      - op: replace 
+        path: /spec/resources/requests/storage
+        value: 10Gi
+  - target:
       kind: StatefulSet
       name: gitserver
     patch: |-
       - op: replace 
         path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
-        value: 10Gi
+        # This is where repositories are cloned and stored
+        value: 30Gi
+  - target:
+      kind: StatefulSet
+      name: indexed-search
+    patch: |-
+      - op: replace 
+        path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
+        # This should be 50% of the storage value assigned to gitserver above
+        value: 15Gi

--- a/overlays/minikube/kustomization.yaml
+++ b/overlays/minikube/kustomization.yaml
@@ -125,8 +125,9 @@ patches:
         # This is the default storage class for minikube
         value: standard
   - target:
-      kind: PersistentVolumeClaim
+      kind: StatefulSet
+      name: gitserver
     patch: |-
       - op: replace 
-        path: /spec/resources/requests/storage
+        path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
         value: 10Gi


### PR DESCRIPTION
<!-- description here -->

In our minikube overlays, the current patch to update the storage spec to 10Gi in the [kustomization.yaml file](https://github.com/sourcegraph/deploy-sourcegraph/blob/v3.43.1/overlays/minikube/kustomization.yaml) only targets PersistentVolumeClaim (pgsql, minios etc), while gitserver and indexed-search are still requesting 200Gi of storage, which might be a lot for a minikube instance considering most of the resources are removed:

```yaml
  volumeClaimTemplates:
  - metadata:
      labels:
        deploy: sourcegraph
      name: data
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 200Gi
      storageClassName: standard
```

This PR adds an extra patch in the kustomization.yaml file for adjusting the storage spec for both  gitserver and indexed-search, which is currently set to 200Gi respectively by default.

Also added instructions in README on how to adjust the values when needed.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

Manually run the generate cluster command to confirm the storage value are updated for `apps_v1_statefulset_gitserver.yaml` file:

```yaml
...
  volumeClaimTemplates:
  - metadata:
      name: repos
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 50Gi
      storageClassName: standard

```

`apps_v1_statefulset_indexed-search.yaml` file:

```yaml
...
  volumeClaimTemplates:
  - metadata:
      labels:
        deploy: sourcegraph
      name: data
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 25Gi
      storageClassName: standard

```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
