### PR TITLE
fix k8s test versions

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -49,7 +49,7 @@ steps:
   - label: ":pulumi: :k8s:"
     concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh 1.20
+    command: .buildkite/integration-test.sh 1.21
     env:
       VERBOSE: "true"
       # Can be set to true to help debug test results, but ensure that created resources
@@ -60,7 +60,7 @@ steps:
   - label: ":pulumi: :k8s:"
     concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh 1.21
+    command: .buildkite/integration-test.sh 1.22
     env:
       VERBOSE: "true"
       # Can be set to true to help debug test results, but ensure that created resources

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -33,19 +33,6 @@ steps:
 
   - wait
 
-  # GKE already drops support for 1.19 hence this test will not run
-  # https://cloud.google.com/kubernetes-engine/docs/release-notes#June_30_2022
-  # - label: ":pulumi: :k8s:"
-  #   concurrency: 6
-  #   concurrency_group: deploy-sourcegraph/integration
-  #   command: .buildkite/integration-test.sh 1.19
-  #   env:
-  #     VERBOSE: "true"
-  #     # Can be set to true to help debug test results, but ensure that created resources
-  #     # are removed manually
-  #     NOCLEANUP: "false"
-  #   agents: { queue: standard }
-
   - label: ":pulumi: :k8s:"
     concurrency: 6
     concurrency_group: deploy-sourcegraph/integration
@@ -56,18 +43,6 @@ steps:
       # are removed manually
       NOCLEANUP: "false"
     agents: { queue: standard }
-
-  - label: ":pulumi: :k8s:"
-    concurrency: 6
-    concurrency_group: deploy-sourcegraph/integration
-    command: .buildkite/integration-test.sh 1.22
-    env:
-      VERBOSE: "true"
-      # Can be set to true to help debug test results, but ensure that created resources
-      # are removed manually
-      NOCLEANUP: "false"
-    agents: { queue: standard }
-
   - label: ":k8s:"
     concurrency: 3
     concurrency_group: deploy-sourcegraph/integration-restricted


### PR DESCRIPTION
k8s 1.20 is no longer available for testing

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

green tests on CI
