### PR TITLE
Update pinned version of docker images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi v1.12.0
 	github.com/sethgrid/pester v1.1.0
-	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220415005223-782c819e0d4d
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220926213859-af1c9d3a8ef2
 	github.com/sourcegraph/update-docker-tags v0.10.0
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,8 @@ github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-2022032720083
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220327200838-d3688ba19706/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220415005223-782c819e0d4d h1:Nwtgu34UDOu41TPERF299lXQGDGB7RDdj+wuLiuhqEA=
 github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220415005223-782c819e0d4d/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220926213859-af1c9d3a8ef2 h1:B9RwWC3kxBv+YYDWBpDrlMRZFhFoRED0Yezq24GlyOY=
+github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220926213859-af1c9d3a8ef2/go.mod h1:RrAuT1kEkrErj2fmr4f3pPDoBF0ruFBhOSC1yORlv24=
 github.com/sourcegraph/update-docker-tags v0.9.0 h1:FeqPS1GH5n4KyTha/SpZvDDmrdS4c+N8cQ3xb4Rlb+A=
 github.com/sourcegraph/update-docker-tags v0.9.0/go.mod h1:lCDsoUnk/ASDbm7UxE7tU3qAUhQxA7xykELHXcLeKFM=
 github.com/sourcegraph/update-docker-tags v0.10.0 h1:KpY1HtvSt0FzDM/sR0jQF5StNbiPKpqmHhE0jpBEa0A=


### PR DESCRIPTION
Just updates the pinned version of the images in the `4.0` branch so that we can run the `update-images` script. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

Tested that `./update-images.sh` works with an updated list of images.