### PR TITLE
otel-agent: add DaemonSet patch for otel-agent which adds podAffinity

### DIFF
--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 resources:
 - ../bases/deployments
 - ../bases/rbac-roles
-              
+
 patches:
 
 - target:
@@ -103,13 +103,13 @@ patches:
     name: codeintel-db
     group: apps
     version: v1
-  path: delete-resources-4.yaml    
+  path: delete-resources-4.yaml
 - target:
     kind: Deployment
     name: codeinsights-db
     group: apps
     version: v1
-  path: delete-resources-4.yaml  
+  path: delete-resources-4.yaml
 - target:
     kind: Deployment
     name: minio
@@ -147,6 +147,10 @@ patches:
   target:
     kind: StatefulSet
     name: grafana
+- path: otel-agent-patch.yaml
+  target:
+    kind: DaemonSet
+    name: otel-agent
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -244,7 +248,7 @@ patches:
             hostPath:
               path: /mnt/disks/ssd0/buildkite/cluster-deployments/
               type: DirectoryOrCreate
-            persistentVolumeClaim: null              
+            persistentVolumeClaim: null
           - name: codeinsights-conf
             configMap:
               defaultMode: 0777
@@ -294,7 +298,7 @@ patches:
         spec:
           containers:
           - name: minio
-            args: 
+            args:
             - minio
             - server
             - /data-minio
@@ -308,7 +312,7 @@ patches:
             - mountPath: /data-minio
               name: minio-data
               subPathExpr: $(POD_NAME)
-          
+
           volumes:
             - name: minio-data
               hostPath:
@@ -374,7 +378,7 @@ patches:
               # directory location on host
               path: /mnt/disks/ssd0/buildkite/cluster-deployments/
               type: DirectoryOrCreate
-            persistentVolumeClaim: null            
+            persistentVolumeClaim: null
   target:
     kind: Deployment
     name: redis-cache
@@ -393,7 +397,7 @@ patches:
                 value: "true"
   target:
     kind: Deployment
-    name: sourcegraph-frontend  
+    name: sourcegraph-frontend
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -419,13 +423,13 @@ patches:
       template:
         spec:
           containers:
-            - name: precise-code-intel-worker 
+            - name: precise-code-intel-worker
               env:
               - name: NEW_MIGRATIONS
                 value: "true"
   target:
     kind: Deployment
-    name: precise-code-intel-worker    
+    name: precise-code-intel-worker
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -441,8 +445,8 @@ patches:
                 value: "true"
   target:
     kind: Deployment
-    name: repo-updater                          
-    
+    name: repo-updater
+
 patchesStrategicMerge:
 - cadvisor/delete-Daemonset.yaml
 - cadvisor/delete-ClusterRole.yaml

--- a/overlays/low-resource/otel-agent-patch.yaml
+++ b/overlays/low-resource/otel-agent-patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+# The podAffinity here ensures that a otel-agent is only scheduled on a Pod with the label deploy=sourcegraph.
+# If the pod already has a Pod scheduled, another one won't be scheduled and the pod status will be Pending
+spec:
+  template:
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: deploy
+                operator: In
+                values:
+                - sourcegraph
+            topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Adds a podAffinity to the otel-agent DaemonSet to make sure the otel-agent **only** runs on nodes where there are other pods which will utilize this. A consequence of this is that there will be a lot of pods in "Pending" state and only a few pods in Running
```
NAME                                        READY   STATUS    RESTARTS      AGE
codeinsights-db-56b65bddd5-hnsb6            2/2     Running   0             33m
codeintel-db-58bd96b769-fj5sl               2/2     Running   0             33m
github-proxy-5d9bbf9f7f-pv9vl               1/1     Running   0             33m
gitserver-0                                 1/1     Running   1 (32m ago)   33m
grafana-0                                   1/1     Running   0             32m
indexed-search-0                            2/2     Running   0             33m
minio-59b9c8b9c6-6mx5p                      1/1     Running   0             33m
otel-agent-59b77                            0/1     Pending   0             22m
otel-agent-5lkpg                            0/1     Pending   0             33m
otel-agent-67496                            0/1     Pending   0             33m
otel-agent-675bd                            0/1     Pending   0             22m
otel-agent-7kr4g                            0/1     Pending   0             33m
otel-agent-7lf94                            0/1     Pending   0             13m
otel-agent-7s29g                            0/1     Pending   0             33m
otel-agent-8bv82                            0/1     Pending   0             13m
otel-agent-8c54q                            0/1     Pending   0             33m
otel-agent-944gf                            0/1     Pending   0             14m
otel-agent-97xvr                            1/1     Running   0             33m
otel-agent-9hkvd                            0/1     Pending   0             33m
otel-agent-9sx49                            0/1     Pending   0             22m
otel-agent-bklrw                            0/1     Pending   0             33m
otel-agent-ch5qc                            0/1     Pending   0             33m
otel-agent-ct7qm                            0/1     Pending   0             22m
otel-agent-cxxvg                            0/1     Pending   0             33m
otel-agent-d77x9                            0/1     Pending   0             22m
otel-agent-dbnnj                            1/1     Running   0             33m
otel-agent-dqc2x                            0/1     Pending   0             22m
otel-agent-dsjwk                            1/1     Running   0             33m
otel-agent-f6h7p                            0/1     Pending   0             33m
otel-agent-fk5k5                            0/1     Pending   0             33m
otel-agent-fqv7d                            0/1     Pending   0             22m
otel-agent-g52sm                            0/1     Pending   0             13m
otel-agent-g58sm                            0/1     Pending   0             33m
otel-agent-gcp94                            0/1     Pending   0             22m
otel-agent-gjcr9                            1/1     Running   0             33m
otel-agent-gjppp                            0/1     Pending   0             13m
otel-agent-gnzjx                            0/1     Pending   0             33m
otel-agent-gs78z                            0/1     Pending   0             22m
otel-agent-gxbks                            0/1     Pending   0             22m
otel-agent-gxjhg                            0/1     Pending   0             33m
otel-agent-hd6sm                            1/1     Running   0             33m
otel-agent-hhbxv                            0/1     Pending   0             13m
otel-agent-jc6rl                            0/1     Pending   0             12m
otel-agent-jd2v7                            0/1     Pending   0             33m
otel-agent-jhwmt                            0/1     Pending   0             13m
otel-agent-jq826                            1/1     Running   0             33m
otel-agent-jtmg7                            1/1     Running   0             33m
otel-agent-k2m2c                            1/1     Running   0             29m
otel-agent-k5q6z                            0/1     Pending   0             33m
otel-agent-kb7bv                            0/1     Pending   0             33m
otel-agent-kcg7k                            0/1     Pending   0             33m
otel-agent-kj44d                            0/1     Pending   0             33m
otel-agent-kjbjm                            0/1     Pending   0             33m
otel-agent-lbgv8                            1/1     Running   0             33m
otel-agent-lcbfs                            0/1     Pending   0             33m
otel-agent-ldjpw                            0/1     Pending   0             33m
otel-agent-ljcjm                            0/1     Pending   0             33m
otel-agent-lp9jz                            0/1     Pending   0             33m
otel-agent-mfwb9                            0/1     Pending   0             13m
otel-agent-mxr4x                            0/1     Pending   0             13m
otel-agent-n6t4b                            1/1     Running   0             33m
otel-agent-nbdjf                            0/1     Pending   0             33m
otel-agent-nkf9s                            0/1     Pending   0             13m
otel-agent-nlpsq                            0/1     Pending   0             33m
otel-agent-nmgqf                            0/1     Pending   0             33m
otel-agent-npslb                            0/1     Pending   0             33m
otel-agent-nqfxp                            1/1     Running   0             33m
otel-agent-p7ztr                            0/1     Pending   0             33m
otel-agent-phrcc                            0/1     Pending   0             33m
otel-agent-pl7dl                            0/1     Pending   0             33m
otel-agent-pwwhq                            0/1     Pending   0             14m
otel-agent-pxlhd                            0/1     Pending   0             33m
otel-agent-q8rfk                            0/1     Pending   0             13m
otel-agent-qg7gw                            0/1     Pending   0             33m
otel-agent-qtwvj                            0/1     Pending   0             33m
otel-agent-r2v4p                            0/1     Pending   0             33m
otel-agent-rjqnd                            0/1     Pending   0             22m
otel-agent-rst9w                            0/1     Pending   0             33m
otel-agent-rsw28                            0/1     Pending   0             33m
otel-agent-rz5hg                            0/1     Pending   0             14m
otel-agent-s4l6t                            0/1     Pending   0             22m
otel-agent-s6qzn                            0/1     Pending   0             33m
otel-agent-scrnd                            0/1     Pending   0             33m
otel-agent-sjfhx                            0/1     Pending   0             33m
otel-agent-sqzpl                            1/1     Running   0             33m
otel-agent-stl2x                            0/1     Pending   0             12m
otel-agent-tg6nr                            0/1     Pending   0             33m
otel-agent-tp5xx                            0/1     Pending   0             33m
otel-agent-ttsns                            0/1     Pending   0             22m
otel-agent-v9b67                            0/1     Pending   0             33m
otel-agent-vskvf                            0/1     Pending   0             33m
otel-agent-w8ll9                            0/1     Pending   0             33m
otel-agent-wtcm9                            0/1     Pending   0             33m
otel-agent-wtcx8                            0/1     Pending   0             33m
otel-agent-xpgdk                            0/1     Pending   0             33m
otel-agent-zffkc                            0/1     Pending   0             22m
otel-agent-zm5m5                            0/1     Pending   0             22m
otel-collector-5d68fbc8dc-82dp4             1/1     Running   0             33m
pgsql-58467c59cb-8mtsq                      2/2     Running   0             33m
precise-code-intel-worker-9bf488d5f-dztp6   1/1     Running   0             33m
precise-code-intel-worker-9bf488d5f-l9vmz   1/1     Running   0             33m
prometheus-7579f4fbc4-rqpn2                 1/1     Running   0             32m
redis-cache-5bb7cdcd5f-5kghh                2/2     Running   0             33m
redis-store-7fcf99bb56-v56hg                2/2     Running   0             33m
repo-updater-7d7685d54b-hx7gw               1/1     Running   0             33m
searcher-5bf75b48f9-j8vxm                   1/1     Running   0             33m
searcher-5bf75b48f9-kk72p                   1/1     Running   0             33m
sourcegraph-frontend-859f7fd5f9-ldt9z       1/1     Running   0             32m
sourcegraph-frontend-859f7fd5f9-svns7       1/1     Running   0             32m
symbols-565df44c5b-ctgf4                    1/1     Running   0             33m
syntect-server-5f94d544df-5f5mk             1/1     Running   0             33m
worker-6f7c6d6dcc-74j9k                     1/1     Running   0             33m

```

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan
1. Created our own namespace
2. Checkout out deploy-sourcegraph
3. run `./overlay-generate-cluster.sh low-resource generated-cluster`
4. `kubectl apply -n "$NAMESPACE" --recursive --validate -f generated-cluster`
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
