### PR TITLE
add node exporter daemonset

### DIFF
--- a/base/node-exporter/node-exporter.DaemonSet.yaml
+++ b/base/node-exporter/node-exporter.DaemonSet.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    description: DaemonSet to ensure all nodes run a node-exporter pod.
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+  labels:
+    deploy: sourcegraph
+    app: node-exporter
+    app.kubernetes.io/component: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      annotations:
+        description: Collects and exports machine metrics.
+        kubectl.kubernetes.io/default-container: node-exporter
+      labels:
+        deploy: sourcegraph
+        app: node-exporter
+    spec:
+      containers:
+      - name: node-exporter
+        image: index.docker.io/sourcegraph/node-exporter:179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
+        imagePullPolicy: IfNotPresent
+        args:
+          - --web.listen-address=:9100
+          - --path.sysfs=/host/sys
+          - --path.rootfs=/host/root
+          - --path.procfs=/host/proc
+          - --no-collector.wifi
+          - --no-collector.hwmon
+          - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+          - --collector.netclass.ignored-devices=^(veth.*)$
+          - --collector.netdev.device-exclude=^(veth.*)$
+        env:
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsUser: 65534
+        volumeMounts:
+        - name: rootfs
+          mountPath: /host/root
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: sys
+          mountPath: /host/sys
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc
+          mountPropagation: HostToContainer
+          readOnly: true
+        ports:
+        - name: metrics
+          containerPort: 9100
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            scheme: HTTP
+            port: metrics
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            scheme: HTTP
+            port: metrics
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        terminationMessagePolicy: FallbackToLogsOnError
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+      affinity:
+      tolerations:
+      hostPID: true
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: proc
+        hostPath:
+          path: /proc

--- a/base/node-exporter/node-exporter.DaemonSet.yaml
+++ b/base/node-exporter/node-exporter.DaemonSet.yaml
@@ -26,6 +26,13 @@ spec:
       - name: node-exporter
         image: index.docker.io/sourcegraph/node-exporter:179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: '1'
+            memory: 1Gi
+          requests:
+            cpu: 200m
+            memory: 100Mi
         args:
           - --web.listen-address=:9100
           - --path.sysfs=/host/sys

--- a/base/node-exporter/node-exporter.Service.yaml
+++ b/base/node-exporter/node-exporter.Service.yaml
@@ -18,7 +18,5 @@ spec:
     port: 9100
     targetPort: metrics
   selector:
-    app.kubernetes.io/name: sourcegraph
-    app.kubernetes.io/instance: sourcegraph
     app: node-exporter
   type: ClusterIP

--- a/base/node-exporter/node-exporter.Service.yaml
+++ b/base/node-exporter/node-exporter.Service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    description: Prometheus exporter for hardware and OS metrics.
+    url: https://github.com/prometheus/node_exporter
+    prometheus.io/port: "9100"
+    sourcegraph.prometheus/scrape: "true"
+  labels:
+    app.kubernetes.io/component: node-exporter
+    app: node-exporter
+    deploy: sourcegraph
+    sourcegraph-resource-requires: no-cluster-admin
+  name: node-exporter
+spec:
+  ports:
+  - name: metrics
+    port: 9100
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: sourcegraph
+    app.kubernetes.io/instance: sourcegraph
+    app: node-exporter
+  type: ClusterIP

--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -163,6 +163,11 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: instance
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        action: replace
+        target_label: nodename
 
     # Example scrape config for probing services via the Blackbox Exporter.
     #
@@ -235,6 +240,11 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: ns
+      # Sourcegraph specific customization. We want to add a label to every 
+      # metric that indicates the node it came from.
+      - source_labels: [__meta_kubernetes_endpoint_node_name]
+        action: replace
+        target_label: nodename
 
       metric_relabel_configs:
       # cAdvisor-specific customization. Drop container metrics exported by cAdvisor

--- a/overlays/bases/deployments/kustomization.yaml
+++ b/overlays/bases/deployments/kustomization.yaml
@@ -54,3 +54,5 @@ resources:
 - base/otel-collector/otel-collector.ConfigMap.yaml
 - base/otel-collector/otel-collector.Deployment.yaml
 - base/otel-collector/otel-collector.Service.yaml
+- base/node-exporter/node-exporter.DaemonSet.yaml
+- base/node-exporter/node-exporter.Service.yaml

--- a/overlays/low-resource/kustomization.yaml
+++ b/overlays/low-resource/kustomization.yaml
@@ -453,5 +453,6 @@ patchesStrategicMerge:
 - cadvisor/delete-ClusterRoleBinding.yaml
 - cadvisor/delete-ServiceAccount.yaml
 - cadvisor/delete-PodSecurityPolicy.yaml
-
+- node-exporter/delete-Daemonset.yaml
+- node-exporter/delete-Service.yaml
 

--- a/overlays/low-resource/node-exporter/delete-Daemonset.yaml
+++ b/overlays/low-resource/node-exporter/delete-Daemonset.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter

--- a/overlays/low-resource/node-exporter/delete-Service.yaml
+++ b/overlays/low-resource/node-exporter/delete-Service.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter


### PR DESCRIPTION

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [x] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated: https://github.com/sourcegraph/sourcegraph/pull/43893
* [x] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md): https://github.com/sourcegraph/sourcegraph/pull/43893
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/874
* [x] All images have a valid tag and SHA256 sum

### Test plan

Using [dyff](https://github.com/homeport/dyff) to compare the manifests against the node-exporter manifests currently running on k8s.sgdev.org @ https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/commit/d066b2d46f312086521973887847ab3a50620ef0


The diffs show no meaningful difference:


DaemonSet:

```
     _        __  __
   _| |_   _ / _|/ _|  between node-exporter.DaemonSet.yaml
 / _' | | | | |_| |_       and out.yaml
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned 18 differences
        |___/

(root level)
+ one map entry added:
  status:
    currentNumberScheduled: 9
    desiredNumberScheduled: 9
    numberAvailable: 9
    numberMisscheduled: 0
    numberReady: 9
    observedGeneration: 13
    updatedNumberScheduled: 9

metadata
  + four map entries added:
    creationTimestamp: "2022-11-02T22:00:33Z"
    generation: 13
    resourceVersion: 384034976
    uid: eef215ee-1f28-4067-b313-3d479cb10d18

metadata.annotations
  + two map entries added:
    deprecated.daemonset.template.generation: 13
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"annotations":{"description":"DaemonSet to ensure all nodes run a node-exporter pod.","seccomp.security.alpha.kubernetes.io/pod":"docker/default"},"labels":{"app":"node-exporter","app.kubernetes.io/component":"node-exporter","app.kubernetes.io/instance":"dogfood-k8s","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"sourcegraph","app.kubernetes.io/version":"insiders","deploy":"sourcegraph","helm.sh/chart":"sourcegraph-4.1.2-insiders.4ac1bcb"},"name":"node-exporter","namespace":"dogfood-k8s"},"spec":{"selector":{"matchLabels":{"app":"node-exporter","app.kubernetes.io/instance":"dogfood-k8s","app.kubernetes.io/name":"sourcegraph"}},"template":{"metadata":{"annotations":{"description":"Collects and exports machine metrics.","kubectl.kubernetes.io/default-container":"node-exporter"},"labels":{"app":"node-exporter","app.kubernetes.io/instance":"dogfood-k8s","app.kubernetes.io/name":"sourcegraph","deploy":"sourcegraph"}},"spec":{"affinity":null,"automountServiceAccountToken":false,"containers":[{"args":["--web.listen-address=:9100","--path.sysfs=/host/sys","--path.rootfs=/host/root","--path.procfs=/host/proc","--no-collector.wifi","--no-collector.hwmon","--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)","--collector.netclass.ignored-devices=^(veth.*)$","--collector.netdev.device-exclude=^(veth.*)$"],"env":null,"image":"index.docker.io/sourcegraph/node-exporter:181392_2022-11-03_7b2e1498e8b1@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f","imagePullPolicy":"IfNotPresent","livenessProbe":{"failureThreshold":3,"httpGet":{"port":"metrics","scheme":"HTTP"},"initialDelaySeconds":0,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1},"name":"node-exporter","ports":[{"containerPort":9100,"name":"metrics","protocol":"TCP"}],"readinessProbe":{"failureThreshold":3,"httpGet":{"port":"metrics","scheme":"HTTP"},"initialDelaySeconds":0,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1},"resources":{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":".2","memory":"100Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsUser":65534},"terminationMessagePolicy":"FallbackToLogsOnError","volumeMounts":[{"mountPath":"/host/root","mountPropagation":"HostToContainer","name":"rootfs","readOnly":true},{"mountPath":"/host/sys","mountPropagation":"HostToContainer","name":"sys","readOnly":true},{"mountPath":"/host/proc","mountPropagation":"HostToContainer","name":"proc","readOnly":true}]}],"hostPID":true,"nodeSelector":null,"securityContext":{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534},"terminationGracePeriodSeconds":30,"tolerations":null,"volumes":[{"hostPath":{"path":"/"},"name":"rootfs"},{"hostPath":{"path":"/sys"},"name":"sys"},{"hostPath":{"path":"/proc"},"name":"proc"}]}}}}
      
    
  

metadata.labels
  + five map entries added:
    app.kubernetes.io/instance: dogfood-k8s
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: sourcegraph
    app.kubernetes.io/version: insiders
    helm.sh/chart: sourcegraph-4.1.2-insiders.4ac1bcb

spec
  + two map entries added:
    revisionHistoryLimit: 10
    updateStrategy:
      type: RollingUpdate
      rollingUpdate:
        maxSurge: 0
        maxUnavailable: 1

spec.selector.matchLabels
  + two map entries added:
    app.kubernetes.io/instance: dogfood-k8s
    app.kubernetes.io/name: sourcegraph

spec.template.metadata
  + one map entry added:
    creationTimestamp: null

spec.template.metadata.labels
  + two map entries added:
    app.kubernetes.io/instance: dogfood-k8s
    app.kubernetes.io/name: sourcegraph

spec.template.spec
  - three map entries removed:     + three map entries added:
    nodeSelector:                    dnsPolicy: ClusterFirst
    affinity:                        restartPolicy: Always
    tolerations:                     schedulerName: default-scheduler

spec.template.spec.containers.node-exporter
  - one map entry removed:     + one map entry added:
    env:                         terminationMessagePath: /dev/termination-log

spec.template.spec.containers.node-exporter.image
  ± value change
    - index.docker.io/sourcegraph/node-exporter:179720_2022-10-25_4d925e87cfb8@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
    + index.docker.io/sourcegraph/node-exporter:181392_2022-11-03_7b2e1498e8b1@sha256:2d9dcdf0b2226f0c3d550a64d2667710265462350a3ba9ebe37d0302bc64af0f
  

spec.template.spec.containers.node-exporter.readinessProbe
  - one map entry removed:
    initialDelaySeconds: 0

spec.template.spec.containers.node-exporter.readinessProbe.httpGet
  + one map entry added:
    path: /

spec.template.spec.containers.node-exporter.livenessProbe
  - one map entry removed:
    initialDelaySeconds: 0

spec.template.spec.containers.node-exporter.livenessProbe.httpGet
  + one map entry added:
    path: /

spec.template.spec.volumes.rootfs.hostPath
  + one map entry added:
    type:

spec.template.spec.volumes.sys.hostPath
  + one map entry added:
    type:

spec.template.spec.volumes.proc.hostPath
  + one map entry added:
    type:

```

Service:

```
     _        __  __
   _| |_   _ / _|/ _|  between node-exporter.Service.yaml
 / _' | | | | |_| |_       and out.svc.yaml
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned seven differences
        |___/

(root level)
+ one map entry added:
  status:
    loadBalancer: {}

metadata
  + three map entries added:
    creationTimestamp: "2022-09-30T18:16:38Z"
    resourceVersion: 378401171
    uid: 2d171ae1-66eb-48ce-8aa9-9a704a178fb1

metadata.annotations
  + two map entries added:
    cloud.google.com/neg: "{"ingress":true}"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"description":"Prometheus exporter for hardware and OS metrics.","prometheus.io/port":"9100","sourcegraph.prometheus/scrape":"true","url":"https://github.com/prometheus/node_exporter"},"labels":{"app":"node-exporter","app.kubernetes.io/component":"node-exporter","app.kubernetes.io/instance":"dogfood-k8s","deploy":"sourcegraph","sourcegraph-resource-requires":"no-cluster-admin"},"name":"node-exporter","namespace":"dogfood-k8s"},"spec":{"ports":[{"name":"metrics","port":9100,"targetPort":"metrics"}],"selector":{"app":"node-exporter","app.kubernetes.io/instance":"dogfood-k8s","app.kubernetes.io/name":"sourcegraph"},"type":"ClusterIP"}}
      
    
  

metadata.labels
  + one map entry added:
    app.kubernetes.io/instance: dogfood-k8s

spec
  + six map entries added:
    clusterIP: 10.253.15.104
    clusterIPs:
    - 10.253.15.104
    internalTrafficPolicy: Cluster
    ipFamilies:
    - IPv4
    ipFamilyPolicy: SingleStack
    sessionAffinity: None

spec.ports.metrics
  + one map entry added:
    protocol: TCP

spec.selector
  + two map entries added:
    app.kubernetes.io/instance: dogfood-k8s
    app.kubernetes.io/name: sourcegraph

```


