### PR TITLE
prometheus: drop labels with duplicate nodename entries

### DIFF
--- a/base/prometheus/prometheus.ConfigMap.yaml
+++ b/base/prometheus/prometheus.ConfigMap.yaml
@@ -168,6 +168,11 @@ data:
       - source_labels: [__meta_kubernetes_endpoint_node_name]
         action: replace
         target_label: nodename
+      metric_relabel_configs:
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
 
     # Example scrape config for probing services via the Blackbox Exporter.
     #
@@ -242,7 +247,7 @@ data:
         target_label: ns
       # Sourcegraph specific customization. We want to add a label to every 
       # metric that indicates the node it came from.
-      - source_labels: [__meta_kubernetes_endpoint_node_name]
+      - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: nodename
 
@@ -265,6 +270,10 @@ data:
         action: replace
         target_label: name
         separator: '-'
+      # Sourcegraph specific customization. Drop metrics with empty nodename responses from the k8s API
+      - source_labels: [nodename]
+        regex: ^$
+        action: drop
 
     # Scrape prometheus itself for metrics.
     - job_name: 'builtin-prometheus'


### PR DESCRIPTION
Follows changes introduced in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/209

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [x] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated: not needed for this change
* [x] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md): not needed for this change
* [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: not needed for this change
* [x] All images have a valid tag and SHA256 sum

### Test plan

CI
