### PR TITLE
executor: deploy on k8s

### DIFF
--- a/configure/executor/docker-daemon.ConfigMap.yaml
+++ b/configure/executor/docker-daemon.ConfigMap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  daemon.json: |
+    { "insecure-registries":["private-docker-registry:5000"] }
+
+kind: ConfigMap
+metadata:
+  labels:
+    deploy: executor
+  name: docker-config
+  namespace: default

--- a/configure/executor/executor.Deployment.yaml
+++ b/configure/executor/executor.Deployment.yaml
@@ -110,4 +110,4 @@ spec:
         - name: docker-config
           configMap:
             defaultMode: 420
-            name: docker-config              
+            name: docker-config

--- a/configure/executor/executor.Deployment.yaml
+++ b/configure/executor/executor.Deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: executor
+  namespace: default
+  labels:
+    deploy: sourcegraph
+spec:
+  selector:
+    matchLabels:
+      app: executor
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: executor
+    spec:
+      containers:
+        - name: executor
+          image: index.docker.io/sourcegraph/executor:insiders
+          imagePullPolicy: Always 
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - executor
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - pgrep
+                - executor
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          terminationMessagePolicy: FallbackToLogsOnError
+          # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables          
+          env:  
+            - name: EXECUTOR_FRONTEND_URL
+              value: 
+            - name: EXECUTOR_FRONTEND_PASSWORD
+              value: 
+            - name: EXECUTOR_USE_FIRECRACKER
+              value: "false"
+            - name: EXECUTOR_QUEUE_NAME
+              value: 
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+            - name: SRC_ACCESS_TOKEN 
+              value: 
+            - name: SRC_ENDPOINT
+              value: 
+          volumeMounts:
+            - mountPath: /tmp
+              name: shared-data              
+        - name: dind
+          image: docker:20.10.22-dind
+          securityContext:
+            privileged: true          
+          command:
+            - 'dockerd'
+            - '--tls=false'
+            - '--mtu=1200'
+            - '--registry-mirror=http://private-docker-registry:5000'
+            - '--host=tcp://0.0.0.0:2375'
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - dockerd
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - pgrep
+                - dockerd
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5            
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          ports:
+            - containerPort: 2375
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: shared-data
+            - mountPath: /etc/docker/daemon.json
+              subPath: daemon.json
+              name: docker-config
+      volumes:
+        - name: shared-data
+          emptyDir:
+            sizeLimit: 5Gi
+        - name: docker-config
+          configMap:
+            defaultMode: 420
+            name: docker-config              

--- a/configure/executor/private-docker-registry/private-docker-registry.Deployment.yaml
+++ b/configure/executor/private-docker-registry/private-docker-registry.Deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: private-docker-registry
+  namespace: default
+  labels:
+    app: private-docker-registry
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: private-docker-registry
+  template:
+    metadata:
+      labels:
+        app: private-docker-registry
+    spec:
+      containers:
+        - image: index.docker.io/registry:2
+          name: private-docker-registry
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REGISTRY_PROXY_REMOTEURL
+              value: http://registry-1.docker.io
+          ports:
+            - containerPort: 5000
+              name: registry
+          livenessProbe:
+            httpGet:
+              path: /
+              port: registry
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: registry
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 5         
+          volumeMounts:
+            - mountPath: /var/lib/registry
+              name: cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: private-docker-registry

--- a/configure/executor/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
+++ b/configure/executor/private-docker-registry/private-docker-registry.PersistentVolumeClaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: private-docker-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: sourcegraph

--- a/configure/executor/private-docker-registry/private-docker-registry.Service.yaml
+++ b/configure/executor/private-docker-registry/private-docker-registry.Service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: private-docker-registry
+  name: private-docker-registry
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: private-docker-registry
+  type: ClusterIP


### PR DESCRIPTION
This is my interpretation of https://github.com/sourcegraph/sourcegraph/issues/42469

It's a WIP as there is no documentation but we need an artefact for folks to deploy as well, and before I can document the process, we need to agree on what that is. 

Right now this creates a single replica, with yet to be determined resource requirements. It deploys a `docker in docker` sidecar to avoid exposing the underlying container runtime on the k8s host. It also deploys a pull through cache to avoid docker rate limiting. 

Assuming this is good, further steps are to ensure this works with kustomize/helm and is documented with a readme and exisiting executor docs are amended. 


### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

Tested running a SSBC on S2

![image](https://user-images.githubusercontent.com/2067825/214379388-0bfaa8c4-1d27-4673-8557-e3df7eab8b7b.png)
