### PR TITLE
Update to Go 1.19.6

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # tag=v2
       - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # renovate: tag=v2
         with:
-          go-version: '^1.14'
+          go-version: '^1.19'
 
       # generate update
       - name: Pin tags to ${{ github.event.inputs.semver }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.3
+golang 1.19.6
 yarn 1.22.4
 kubectl 1.21.7
 fd 7.4.0


### PR DESCRIPTION
Update to 1.19.6 because it fixes a bunch of CVEs.

[_Created by Sourcegraph batch change `jhchabran/update-to-go-1.19.6`._](https://sourcegraph.sourcegraph.com/users/jhchabran/batch-changes/update-to-go-1.19.6)

Test Plan: CI