### PR TITLE
executors: fix bugs in manifests

### DIFF
--- a/configure/executors/executor/executor.Deployment.yaml
+++ b/configure/executors/executor/executor.Deployment.yaml
@@ -31,15 +31,18 @@ spec:
           image: index.docker.io/sourcegraph/executor:insiders@sha256:deda81624796df31b56bdaa6820b3332eaa2cbe5e1729886d15ce3c6f57b69b5
           imagePullPolicy: Always
           livenessProbe:
-            command:
-              - /usr/local/bin/executor
-              - validate
+            exec:
+              command:
+                - /usr/local/bin/executor
+                - validate
             initialDelaySeconds: 60
-            timeoutSeconds: 5
+            timeoutSeconds: 30
           readinessProbe:
-            command:
-              - /usr/local/bin/executor
-              - validate
+            exec:
+              command:
+                - /usr/local/bin/executor
+                - validate
+            timeoutSeconds: 30
           terminationMessagePolicy: FallbackToLogsOnError
           # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
           env:
@@ -64,7 +67,8 @@ spec:
             - mountPath: /scratch
               name: executor-scratch
         - name: dind
-          image: index.docker.io/sourcegraph/dind:insiders@sha256:c8b70b89e8a2c3022ca94320f9e3237847209218463c365058718d492fb83f4a
+          image: index.docker.io/sourcegraph/dind:insiders@sha256:06a4a6ac7c200cdd14ebb1cde5be3f02e5df525e1a3e4c1bc258b08e514e550c
+          imagePullPolicy: Always
           securityContext:
             privileged: true
           command:
@@ -102,7 +106,9 @@ spec:
               name: docker-config
       volumes:
         - name: executor-scratch
-          emptyDir: {}
+          emptyDir:
+            # Ensure we don't cause disk pressure on nodes. This value can be adjusted based on the size of the batch change or code intel requirements.
+            sizeLimit: 10Gi
         - name: docker-config
           configMap:
             defaultMode: 420

--- a/configure/executors/executor/executor.Deployment.yaml
+++ b/configure/executors/executor/executor.Deployment.yaml
@@ -33,16 +33,16 @@ spec:
           livenessProbe:
             exec:
               command:
+                - /usr/bin/pgrep
                 - /usr/local/bin/executor
-                - validate
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
+                - /usr/bin/pgrep
                 - /usr/local/bin/executor
-                - validate
-            timeoutSeconds: 30
+            periodSeconds: 5
           terminationMessagePolicy: FallbackToLogsOnError
           # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
           env:
@@ -108,7 +108,8 @@ spec:
         - name: executor-scratch
           emptyDir:
             # Ensure we don't cause disk pressure on nodes. This value can be adjusted based on the size of the batch change or code intel requirements.
-            sizeLimit: 10Gi
+            # Refer to https://docs.sourcegraph.com/admin/executors/deploy_executors#resource-recommendations for more information
+            sizeLimit: 20Gi
         - name: docker-config
           configMap:
             defaultMode: 420

--- a/configure/executors/executor/executor.Deployment.yaml
+++ b/configure/executors/executor/executor.Deployment.yaml
@@ -28,25 +28,18 @@ spec:
     spec:
       containers:
         - name: executor
-          image: index.docker.io/sourcegraph/executor:insiders@sha256:dfeef2e31d6c7b9bc3e5bf581180668f7c033ffcf1fff9d3d6380b7b998d4c2b
+          image: index.docker.io/sourcegraph/executor:insiders@sha256:deda81624796df31b56bdaa6820b3332eaa2cbe5e1729886d15ce3c6f57b69b5
           imagePullPolicy: Always
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: debug
-              scheme: HTTP
+            command:
+              - /usr/local/bin/executor
+              - validate
             initialDelaySeconds: 60
             timeoutSeconds: 5
           readinessProbe:
-            httpGet:
-              path: /ready
-              port: debug
-              scheme: HTTP
-            periodSeconds: 5
-            timeoutSeconds: 5
-          ports:
-            - containerPort: 6060
-              name: debug
+            command:
+              - /usr/local/bin/executor
+              - validate
           terminationMessagePolicy: FallbackToLogsOnError
           # Refer to https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables on how to populate these variables
           env:
@@ -71,7 +64,7 @@ spec:
             - mountPath: /scratch
               name: executor-scratch
         - name: dind
-          image: docker:20.10.22-dind@sha256:03f2d563100b9776283de1e18f10a1f0b66d2fdc7918831bf8db1cda767d6b37
+          image: index.docker.io/sourcegraph/dind:insiders@sha256:c8b70b89e8a2c3022ca94320f9e3237847209218463c365058718d492fb83f4a
           securityContext:
             privileged: true
           command:

--- a/configure/executors/private-docker-registry/private-docker-registry.Deployment.yaml
+++ b/configure/executors/private-docker-registry/private-docker-registry.Deployment.yaml
@@ -7,13 +7,16 @@ metadata:
     sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: private-docker-registry
 spec:
-  replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       app: private-docker-registry
+  replicas: 1
+  strategy:
+    type: Recreate
   template:
+    metadata:
+      labels:
+        app: private-docker-registry
     spec:
       containers:
         - image: index.docker.io/registry:2
@@ -38,7 +41,7 @@ spec:
               port: registry
               scheme: HTTP
             periodSeconds: 5
-            timeoutSeconds: 5         
+            timeoutSeconds: 5
           volumeMounts:
             - mountPath: /var/lib/registry
               name: cache


### PR DESCRIPTION
This PR fixes an issue with the metadata on the private docker registry. It also adds in an updated image with NO cve's and limits the scratch storage to avoid the pod being evicted for causing disk pressure based on the docs. 

It also fixes the liveness/readiness probes for the executor. 

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

Tested on dogfood. 
