### PR TITLE
Fix: update `src-cli` version to latest for tests

### DIFF
--- a/tests/integration/restricted/install-src.sh
+++ b/tests/integration/restricted/install-src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-target_src_version="3.35.1"
+target_src_version="5.0.2"
 current_src_version=$(src version | grep -i current | sed 's/current version: //i')
 
 if [ "$current_src_version" != "$target_src_version" ]; then

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -102,7 +102,8 @@ CLEANUP="kill $!; $CLEANUP"
 sleep 2 # (initial delay in port-forward activating)
 curl --retry-connrefused --retry 2 --retry-delay 10 -m 30 http://localhost:30080
 
-/usr/local/bin/src -endpoint http://localhost:30080 version
+/usr/local/bin/src version
 
 # run a validation script against it
-/usr/local/bin/src -endpoint http://localhost:30080 validate -context github_token=$GH_TOKEN validate.json
+ADMIN_TOKEN=$(/usr/local/bin/src admin create --url http://localhost:30080 --username e2e-test-user --email e2e@sourcegraph.com --password 123123123-e2e-test --with-token)
+SRC_ACCESS_TOKEN=$ADMIN_TOKEN SRC_GITHUB_TOKEN=$GH_TOKEN SRC_ENDPOINT=http://localhost:30080/ /usr/local/bin/src validate install validate.json

--- a/tests/integration/restricted/test.sh
+++ b/tests/integration/restricted/test.sh
@@ -105,5 +105,6 @@ curl --retry-connrefused --retry 2 --retry-delay 10 -m 30 http://localhost:30080
 /usr/local/bin/src version
 
 # run a validation script against it
-ADMIN_TOKEN=$(/usr/local/bin/src admin create --url http://localhost:30080 --username e2e-test-user --email e2e@sourcegraph.com --password 123123123-e2e-test --with-token)
+# '2>&1' is work around bug where token is output to stderr instead of stdout. Will be patched in 5.0.3 of src-cli
+ADMIN_TOKEN=$(/usr/local/bin/src admin create --url http://localhost:30080 --username e2e-test-user --email e2e@sourcegraph.com --password 123123123-e2e-test --with-token 2>&1)
 SRC_ACCESS_TOKEN=$ADMIN_TOKEN SRC_GITHUB_TOKEN=$GH_TOKEN SRC_ENDPOINT=http://localhost:30080/ /usr/local/bin/src validate install validate.json

--- a/tests/integration/restricted/validate.json
+++ b/tests/integration/restricted/validate.json
@@ -1,26 +1,22 @@
 {
-  "firstAdmin": {
-    "email": "e2e@sourcegrah.com",
-    "username": "e2e-test-user",
-    "password": "123123123-e2e-test"
-  },
   "externalService": {
-    "config": {
-      "url": "https://github.com",
-      "token": "{{ .github_token }}",
-      "orgs": [],
-      "repos": [
-        "sourcegraph-testing/repo-ssh-keys-test"
-      ]
-    },
     "kind": "GITHUB",
     "displayName": "footest",
-    "deleteWhenDone": true
+    "deleteWhenDone": true,
+    "maxRetries": 10,
+    "retryTimeoutSeconds": 10,
+    "config": {
+      "gitHub": {
+        "url": "https://github.com",
+        "orgs": [],
+        "repos": [
+          "sourcegraph-testing/repo-ssh-keys-test"
+        ]
+      }
+    }
   },
-  "waitRepoCloned": {
-    "repo": "github.com/sourcegraph-testing/repo-ssh-keys-test",
-    "maxTries": 10,
-    "sleepBetweenTriesSeconds": 10
-  },
-  "searchQuery": "repo:^github.com/sourcegraph-testing/repo-ssh-keys-test$ gallery-director-drone-vacant-blizzard"
+
+  "searchQuery": [
+    "repo:^github.com/sourcegraph-testing/repo-ssh-keys-test$ gallery-director-drone-vacant-blizzard"
+  ]
 }


### PR DESCRIPTION
<!-- description here -->
Update integration tests to use newer version of `src-cli`:

* Update `src-cli` version used in integration tests to latest 5.0.2 version.
* Update `validate.json` schema to reflect new version.
* Add workaround for `src-cli admin create` bug that outputs token to stderr instead of stdout.
* Fix https://github.com/sourcegraph/sourcegraph/issues/48093

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* N/A [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* N/A [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* N/A Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* N/A All images have a valid tag and SHA256 sum

### Test plan
Changes are to tests themselves.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
