### PR TITLE
Add notice for new preferred k8s repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
+### Description
+
 <!-- description here -->
+
+> NOTE:
 
 ### Checklist
 
@@ -8,10 +12,12 @@
   this repository. If uneeded, add link or explanation of why it is not needed here.
 -->
 
-* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
-* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
-* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
-* [ ] All images have a valid tag and SHA256 sum
+- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
+- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
+- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
+- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
+- [ ] All images have a valid tag and SHA256 sum
+- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository
 
 ### Test plan
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,26 @@
 
 [![sourcegraph: search](https://img.shields.io/badge/sourcegraph-search-brightgreen.svg)](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph) [![master build status](https://badge.buildkite.com/018ed23ed79d7297e7dd109b745597c58d875323fb06e81786.svg?branch=master)](https://buildkite.com/sourcegraph/deploy-sourcegraph)
 
-> 🚨 IMPORTANT: When upgrading Sourcegraph, please check [upgrading docs](https://docs.sourcegraph.com/admin/updates/kubernetes) to check if any manual migrations are necessary.
->
-> The `master` branch tracks development. Use the branch of this repository corresponding to the
-> version of Sourcegraph you wish to deploy, e.g. `git checkout 3.19`.
+## Important Notice
+
+🚨 The [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository is now the preferred and officially supported repository for deploying Sourcegraph on Kubernetes.
+
+All new Sourcegraph Kubernetes (without Helm) deployments should use the [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository. Existing deployments will continue to receive security and critical bugfix updates in this repository for the time being. However, we recommend migrating to the [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository for the best experience and to ensure you have the latest features and improvements. Please refer to the [migration docs for Kustomize](https://docs.sourcegraph.com/admin/deploy/kubernetes/kustomize/migrate) for more information.
+
+Both repositories will be supported in parallel until further notice. All new changes and updates will be made in the [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) repository and sync'd to this repository when possible. We recommend using [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) for the most current deployment options.
+
+Please contact us at support@sourcegraph.com if you have any concerns or questions about this migration. Thank you!
+
+## Deploying
 
 Deploying Sourcegraph into a Kubernetes cluster is for organizations that need highly scalable and
 available code search and code intelligence. This repository contains documentation for creating,
 updating, and maintaining a Sourcegraph cluster.
+
+> IMPORTANT: When upgrading Sourcegraph, please check [upgrading docs](https://docs.sourcegraph.com/admin/updates/kubernetes) to check if any manual migrations are necessary.
+>
+> The `master` branch tracks development. Use the branch of this repository corresponding to the
+> version of Sourcegraph you wish to deploy, e.g. `git checkout 3.19`.
 
 For product and [pricing](https://about.sourcegraph.com/pricing/) information, visit
 [about.sourcegraph.com](https://about.sourcegraph.com) or [contact


### PR DESCRIPTION
RE https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/20 and suggested by @daxmc99 

Add notice for our plan on moving away from the deploy-sourcegraph repo and make sure both internal and external users are aware of [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) as the new preferred k8s repo.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

* [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
* [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
* [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
* [ ] All images have a valid tag and SHA256 sum

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

docs update 
