### PR TITLE
update insiders to 5.2.1 tags

### DIFF
--- a/configure/embeddings/embeddings.Deployment.yaml
+++ b/configure/embeddings/embeddings.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: embeddings
-          image: index.docker.io/sourcegraph/embeddings:insiders@sha256:6bfffb3f0d15a4f71d70989656a35d617021574b9081304602e310436ce9f3f9
+          image: index.docker.io/sourcegraph/embeddings:5.2.1@sha256:53da35c505a4abf91e3276ff5ce9514f38445c07ae9d2112400900eea365e71e
           env:
             - name: POD_NAME
               valueFrom:

--- a/configure/executors/dind/executor.Deployment.yaml
+++ b/configure/executors/dind/executor.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - mountPath: /scratch
               name: executor-scratch
         - name: dind
-          image: index.docker.io/sourcegraph/dind:insiders@sha256:d785f0b98f4aca475ee20b6c1e9a09e8a02ff51e4802034f17e7b33ae2fd2825
+          image: index.docker.io/sourcegraph/dind:5.2.1@sha256:dc5dee92728a0a58e92ad249ee4e6cbf068b8e77ad7870ee73293b55074cc920
           imagePullPolicy: Always
           securityContext:
             privileged: true

--- a/configure/executors/k8s/executor.Deployment.yaml
+++ b/configure/executors/k8s/executor.Deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: executor
       containers:
         - name: executor
-          image: index.docker.io/sourcegraph/executor-kubernetes:insiders@sha256:83255544f6837576419008008f7a4b7c19cad1831001ba7176311930539d3d9e
+          image: index.docker.io/sourcegraph/executor-kubernetes:5.2.1@sha256:f8262493086be3641252955fb2b958cfefe50305d7091225da022e644e7443eb
           imagePullPolicy: Always
           livenessProbe:
             exec:


### PR DESCRIPTION
This shouldn't happen. We need to work out what happened in our release tooling. I did this manually by just visiting the respective pages on dockerhub.

Test Plan: docker pull each image.