### PR TITLE
rfc-795: add release manifest

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,13 +23,13 @@ steps:
     command: .buildkite/verify-release/verify-release.sh
     agents: { queue: standard }
 
-  - label: ":k8s: :sleuth_or_spy:" 
+  - label: ":k8s: :sleuth_or_spy:"
     command: .buildkite/check-image-names.sh
     agents: { queue: standard }
 
   - label: ":k8s:"
     command: .buildkite/verify-overlays.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
 
   - wait
 
@@ -59,3 +59,31 @@ steps:
   - label: ":k8s:"
     command: .buildkite/cleanup-disks.sh
     agents: { queue: standard }
+
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
+
+  - wait
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote to public: finalize"
+    if: build.message =~ /^promote_release/ && build.branch =~ /^wip-release/
+    command: |
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/release.yaml
+++ b/release.yaml
@@ -194,6 +194,7 @@ internal:
     steps:
       - name: "git"
         cmd: |
+          set -e
           git checkout -b wip-release-{{version}}
           git push origin wip-release-{{version}}
           git checkout -
@@ -264,6 +265,7 @@ promoteToPublic:
           git commit -m "promote_release: {{version}}" -m '{{config}}'
       - name: "github"
         cmd: |
+          set -e
           git push origin promote-release_{{version}}
           gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}} --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
@@ -271,6 +273,7 @@ promoteToPublic:
     steps:
       - name: git:tag
         cmd: |
+          set -e
           branch="wip-release-{{version}}"
           git checkout ${branch}
           git tag {{version}}

--- a/release.yaml
+++ b/release.yaml
@@ -45,15 +45,18 @@ internal:
             done
         - name: "sg ops (configure)"
           cmd: |
-            sg-rfc795 ops update-images \
-              --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
-              --docker-username=$DOCKER_USERNAME \
-              --docker-password=$DOCKER_PASSWORD \
-              --pin-tag {{inputs.server.tag}} \
-              configure/
+            folders=$(find configure -type d -d 1)
 
-            exit 1
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
         - name: "git:branch"
           cmd: |
             echo "Creating branch wip_{{version}}"
@@ -76,7 +79,6 @@ internal:
       minor:
         - name: "sg ops (base)"
           cmd: |
-            exit 0
             sg-rfc795 ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
@@ -86,7 +88,6 @@ internal:
               base/
         - name: "sg ops (overlays)"
           cmd: |
-            exit 0
             folders=$(find overlays -type d -d 1 \! -name "low-resource")
 
             for path in $folders; do
@@ -113,7 +114,6 @@ internal:
                 --pin-tag {{inputs.server.tag}} \
                 ${path}/
             done
-            exit 1
         - name: "git:branch"
           cmd: |
             echo "Creating branch wip_{{version}}"
@@ -145,24 +145,32 @@ internal:
               base/
         - name: "sg ops (overlays)"
           cmd: |
-            sg-rfc795 ops update-images \
-              --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
-              --docker-username=$DOCKER_USERNAME \
-              --docker-password=$DOCKER_PASSWORD \
-              --pin-tag {{inputs.server.tag}} \
-              overlays/
+            folders=$(find overlays -type d -d 1 \! -name "low-resource")
+
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
         - name: "sg ops (configure)"
           cmd: |
-            sg-rfc795 ops update-images \
-              --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
-              --docker-username=$DOCKER_USERNAME \
-              --docker-password=$DOCKER_PASSWORD \
-              --pin-tag {{inputs.server.tag}} \
-              configure/
+            folders=$(find configure -type d -d 1)
 
-            exit 1
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
         - name: "git:branch"
           cmd: |
             echo "Creating branch wip_{{version}}"
@@ -208,7 +216,7 @@ promoteToPublic:
         cmd: |
           sg-rfc795 ops update-images \
             --kind k8s \
-            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
@@ -229,15 +237,18 @@ promoteToPublic:
           done
       - name: "sg ops (configure)"
         cmd: |
-          sg-rfc795 ops update-images \
-            --kind k8s \
-            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
-            --docker-username=$DOCKER_USERNAME \
-            --docker-password=$DOCKER_PASSWORD \
-            --pin-tag {{inputs.server.tag}} \
-            configure/
+          folders=$(find configure -type d -d 1)
 
-          exit 1
+          for path in $folders; do
+            echo "updating ${path}"
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              ${path}/
+          done
       - name: "git:branch"
         cmd: |
           echo "Creating branch promote-release_{{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,266 @@
+meta:
+  productName: deploy-sourcegraph
+  repository: "github.com/sourcegraph/deploy-sourcegraph"
+  owners:
+    - "@sourcegraph/release"
+
+inputs:
+  - releaseId: server
+
+requirements:
+  - name: "Github CLI"
+    cmd: gh version
+    fixInstructions: brew install gh
+  - name: "Docker username"
+    env: DOCKER_USERNAME
+  - name: "Docker password"
+    env: DOCKER_PASSWORD
+
+internal:
+  create:
+    steps:
+      patch:
+        - name: "sg ops (base)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              base/
+        - name: "sg ops (overlays)"
+          cmd: |
+            folders=$(find overlays -type d -d 1 \! -name "low-resource")
+
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
+        - name: "sg ops (configure)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              configure/
+
+            exit 1
+        - name: "git:branch"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git:commit"
+          cmd: |
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_patch: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+      minor:
+        - name: "sg ops (base)"
+          cmd: |
+            exit 0
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              base/
+        - name: "sg ops (overlays)"
+          cmd: |
+            exit 0
+            folders=$(find overlays -type d -d 1 \! -name "low-resource")
+
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
+        - name: "sg ops (configure)"
+          cmd: |
+            folders=$(find configure -type d -d 1)
+
+            for path in $folders; do
+              echo "updating ${path}"
+              sg-rfc795 ops update-images \
+                --kind k8s \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --docker-username=$DOCKER_USERNAME \
+                --docker-password=$DOCKER_PASSWORD \
+                --pin-tag {{inputs.server.tag}} \
+                ${path}/
+            done
+            exit 1
+        - name: "git:branch"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git:commit"
+          cmd: |
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_minor: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+      major:
+        - name: "sg ops (base)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              base/
+        - name: "sg ops (overlays)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              overlays/
+        - name: "sg ops (configure)"
+          cmd: |
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              configure/
+
+            exit 1
+        - name: "git:branch"
+          cmd: |
+            echo "Creating branch wip_{{version}}"
+            release_branch="wip_{{version}}"
+            git checkout -b $release_branch
+        - name: "git:commit"
+          cmd: |
+            find . -name "*.yaml" | xargs git add
+            find . -name "*.yml" | xargs git add
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_patch: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            git push origin wip_{{version}}
+        - name: "gh cli"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"  # -l "wip_release"
+  finalize:
+    steps:
+      - name: "git"
+        cmd: |
+          git checkout -b wip-release-{{version}}
+          git push origin wip-release-{{version}}
+          git checkout -
+
+test:
+  steps:
+    - name: "placeholder"
+      cmd: |
+        echo "-- pretending to test release ..."
+
+promoteToPublic:
+  create:
+    steps:
+      - name: "git"
+        cmd: |
+          echo "Checking out origin/wip-release-{{version}}"
+          git fetch origin
+          git checkout origin/wip-release-{{version}}
+      - name: "sg ops (base)"
+        cmd: |
+          sg-rfc795 ops update-images \
+            --kind k8s \
+            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            base/
+      - name: "sg ops (overlays)"
+        cmd: |
+          folders=$(find overlays -type d -d 1 \! -name "low-resource")
+
+          for path in $folders; do
+            echo "updating ${path}"
+            sg-rfc795 ops update-images \
+              --kind k8s \
+              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              ${path}/
+          done
+      - name: "sg ops (configure)"
+        cmd: |
+          sg-rfc795 ops update-images \
+            --kind k8s \
+            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            configure/
+
+          exit 1
+      - name: "git:branch"
+        cmd: |
+          echo "Creating branch promote-release_{{version}}"
+          branch="promote-release_{{version}}"
+          git checkout -b $branch
+      - name: "git:commit"
+        cmd: |
+          find . -name "*.yaml" | xargs git add
+          find . -name "*.yml" | xargs git add
+          # Careful with the quoting for the config, using double quotes will lead
+          # to the shell dropping out all quotes from the json, leading to failed
+          # parsing.
+          git commit -m "promote_release: {{version}}" -m '{{config}}'
+      - name: "github"
+        cmd: |
+          git push origin promote-release_{{version}}
+          gh pr create -f -t "PRETEND PROMOTE RELEASE WIP: promote-release: build {{version}}" --base wip-release-{{version}} --body "Test plan: automated release PR, CI will perform additional checks"
+  finalize:
+    # These steps should only really run once the pr created in the create step is merged
+    steps:
+      - name: git:tag
+        cmd: |
+          branch="wip-release-{{version}}"
+          git checkout ${branch}
+          git tag {{version}}
+          git push origin ${branch} --tags


### PR DESCRIPTION
Adds a release manifest

PR created from release tooling:
- https://github.com/sourcegraph/deploy-sourcegraph/pull/4293

[Build](https://buildkite.com/sourcegraph/deploy-sourcegraph/builds/28783#018d7f43-68db-4c33-afd8-f77fedddd668) with release steps

Closes https://github.com/sourcegraph/sourcegraph/issues/59063

### Test plan
1. run release tooling
2. git diff -P | grep "image:" > p1
3. git reset --hard
4. `./tools/update-image-tags.sh "~5.3.0"`
5. git diff -P | grep "image:" > p2

Now we can compare the image changes made by new and old tooling
```
cat p1 | wc -l
86
cat p2 | wc -l
88
```
the extra image that is updated in the old tooling is the migrator.