### PR TITLE
chg/rel: use normal `sg` instead of custom one

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -22,7 +22,7 @@ internal:
       patch:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -35,7 +35,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -49,7 +49,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -79,7 +79,7 @@ internal:
       minor:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -92,7 +92,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -106,7 +106,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -136,7 +136,7 @@ internal:
       major:
         - name: "sg ops (base)"
           cmd: |
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
               --docker-username=$DOCKER_USERNAME \
@@ -149,7 +149,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -163,7 +163,7 @@ internal:
 
             for path in $folders; do
               echo "updating ${path}"
-              sg-rfc795 ops update-images \
+              sg ops update-images \
                 --kind k8s \
                 --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
                 --docker-username=$DOCKER_USERNAME \
@@ -215,7 +215,7 @@ promoteToPublic:
           git checkout origin/wip-release-{{version}}
       - name: "sg ops (base)"
         cmd: |
-          sg-rfc795 ops update-images \
+          sg ops update-images \
             --kind k8s \
             --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
             --docker-username=$DOCKER_USERNAME \
@@ -228,7 +228,7 @@ promoteToPublic:
 
           for path in $folders; do
             echo "updating ${path}"
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
               --docker-username=$DOCKER_USERNAME \
@@ -242,7 +242,7 @@ promoteToPublic:
 
           for path in $folders; do
             echo "updating ${path}"
-            sg-rfc795 ops update-images \
+            sg ops update-images \
               --kind k8s \
               --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
               --docker-username=$DOCKER_USERNAME \


### PR DESCRIPTION
Until we merged this on `main` on sg/sg, we had to use a custom built sg that we uploaded on a GCS bucket

While I was looking at this repo, I think we should make configurable which registry to use, sounds like having a default value in the env bit at the beginning of the manifest would be neat. 

### Description

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

CI 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
