### PR TITLE
release: fix internal and set public registry to docker

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -37,7 +37,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -51,7 +51,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -103,7 +103,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -117,7 +117,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -169,7 +169,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -183,7 +183,7 @@ internal:
               echo "updating ${path}"
               sg ops update-images \
                 --kind k8s \
-                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+                --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal \
                 --docker-username=$DOCKER_USERNAME \
                 --docker-password=$DOCKER_PASSWORD \
                 --pin-tag {{inputs.server.tag}} \
@@ -255,7 +255,7 @@ promoteToPublic:
         cmd: |
           sg ops update-images \
             --kind k8s \
-            --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+            index.docker.io/sourcegraph \
             --docker-username=$DOCKER_USERNAME \
             --docker-password=$DOCKER_PASSWORD \
             --pin-tag {{inputs.server.tag}} \
@@ -268,7 +268,7 @@ promoteToPublic:
             echo "updating ${path}"
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+              index.docker.io/sourcegraph \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \
@@ -282,7 +282,7 @@ promoteToPublic:
             echo "updating ${path}"
             sg ops update-images \
               --kind k8s \
-              --registry us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public \
+              index.docker.io/sourcegraph \
               --docker-username=$DOCKER_USERNAME \
               --docker-password=$DOCKER_PASSWORD \
               --pin-tag {{inputs.server.tag}} \


### PR DESCRIPTION
- Fix all internal registries to be internal
- Switch public registry to `index.docker.io/sourcegraph`

### Test plan
CI