### PR TITLE
misc(release): plug release registry

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -219,6 +219,27 @@ internal:
             echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
+      - name: 'Register on release registry'
+        cmd: |
+          echo "Registering internal deploy-sourcegraph {{version}} release on release registry"
+          COMMIT_SHA=$(git rev-parse HEAD)
+          body=$(curl -s --fail-with-body -X POST "https://releaseregistry.sourcegraph.com/v1/releases" -H "Content-Type: application/json" -H "Authorization: ${RELEASE_REGISTRY_TOKEN}" -d '{
+              "name": "deploy-sourcegraph",
+              "version": "{{version}}",
+              "git_sha": "${COMMIT_SHA}"
+            }')
+          exit_code=$?
+
+          if [ $exit_code != 0 ]; then
+            echo "❌ Failed to create release in release registry, got:"
+            echo "--- raw body ---"
+            echo $body
+            echo "--- raw body ---"
+            exit $exit_code
+          else
+            echo "Release created, see:"
+            echo $body | jq .web_url
+          fi
       - name: "notifications"
         cmd: |
           set -eu
@@ -354,3 +375,19 @@ promoteToPublic:
           cat << EOF | buildkite-agent annotate --style info
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph/tree/{{version}}).
           EOF
+      - name: 'Promote on release registry'
+        cmd: |
+          echo "Promoting deploy-sourcegraph {{version}} release on release registry"
+            body=$(curl -s --fail-with-body -X POST "https://releaseregistry.sourcegraph.com/v1/releases/deploy-sourcegraph/{{version}}/promote" -H "Content-Type: application/json" -H "Authorization: ${RELEASE_REGISTRY_TOKEN}")
+            exit_code=$?
+
+            if [ $exit_code != 0 ]; then
+              echo "❌ Failed to promote release on release registry, got:"
+              echo "--- raw body ---"
+              echo $body
+              echo "--- raw body ---"
+              exit $exit_code
+            else
+              echo "Release promoted, see:"
+              echo $body | jq .web_url
+            fi


### PR DESCRIPTION
### Description

Plugs the release registry into release.yaml
<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [x] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Presumed working, copied from deploy-sourcegarph
