### PR TITLE
Pass tokens for uploading SCIP indexes

### DIFF
--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -17,5 +17,13 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Generate SCIP data
         run: scip-go
-      - name: Upload SCIP data
-        run: src code-intel upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SCIP to Cloud
+        run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
+      - name: Upload SCIP to S2
+        run: src code-intel upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
+          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}


### PR DESCRIPTION
### Description

Tokens are needed for SCIP uploads now

Fixes GRAPH-600

Related PR in deploy-sourcegraph-k8s:
- https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/134

### Checklist

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

n/a