### PR TITLE
Release Tooling: remove qa- from branch creation and tag naming during release

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -369,12 +369,12 @@ promoteToPublic:
           # Branches
           internal_branch="internal/release-{{version}}"
           promote_branch="promote/release-{{version}}"
-          release_branch="qa-release-{{version}}"
+          release_branch="release-{{version}}"
 
           # Create the final branch holding the tagged commit
           git checkout "${promote_branch}"
           git switch -c "${release_branch}"
-          git tag qa-{{version}}
+          git tag {{version}}
           git push origin ${release_branch} --tags
 
           # Web URL to the tag


### PR DESCRIPTION
### Description

I'm worried that the `qa-` prefix in the tags here is going to mess up pings logic for latest version see: 
https://linear.app/sourcegraph/issue/REL-85/admin-updates-page-updates-page-not-displaying-latest-releases

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

No test required here

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
