### PR TITLE
Fix Redis readinessProbe

### DIFF
--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -37,8 +37,22 @@ spec:
           name: redis
         readinessProbe:
           initialDelaySeconds: 5
-          tcpSocket:
-            port: redis
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                #!/bin/bash
+                if [ -f /etc/redis/redis.conf ]; then
+                  export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                fi
+                response=$(
+                  redis-cli ping
+                )
+                if [ "$response" != "PONG" ]; then
+                  echo "$response"
+                  exit 1
+                fi
         resources:
           limits:
             cpu: "1"

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -36,8 +36,22 @@ spec:
           name: redis
         readinessProbe:
           initialDelaySeconds: 5
-          tcpSocket:
-            port: redis
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                #!/bin/bash
+                if [ -f /etc/redis/redis.conf ]; then
+                  export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                fi
+                response=$(
+                  redis-cli ping
+                )
+                if [ "$response" != "PONG" ]; then
+                  echo "$response"
+                  exit 1
+                fi
         resources:
           limits:
             cpu: "1"


### PR DESCRIPTION
### Description
Fix Redis readinessProbe
https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/458

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan
Deploy locally

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
