### PR TITLE
fix redis readiness to handle for no password

### DIFF
--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -36,15 +36,17 @@ spec:
         - containerPort: 6379
           name: redis
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
           exec:
             command:
               - /bin/sh
               - -c
               - |
                 #!/bin/bash
-                if [ -f /etc/redis/redis.conf ]; then
-                  export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                if [ ! -z "$PASS_CHECK" ]; then
+                  export REDISCLI_AUTH="$PASS_CHECK"
                 fi
                 response=$(
                   redis-cli ping

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -35,15 +35,17 @@ spec:
         - containerPort: 6379
           name: redis
         readinessProbe:
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
           exec:
             command:
               - /bin/sh
               - -c
               - |
                 #!/bin/bash
-                if [ -f /etc/redis/redis.conf ]; then
-                  export REDISCLI_AUTH=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                PASS_CHECK=$(grep -h "requirepass" /etc/redis/redis.conf | cut -d ' ' -f 2)
+                if [ ! -z "$PASS_CHECK" ]; then
+                  export REDISCLI_AUTH="$PASS_CHECK"
                 fi
                 response=$(
                   redis-cli ping


### PR DESCRIPTION
### Description
fix the readiness probe fix, to correctly handle for passwords

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan
tested with and without password on kind

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
