### PR TITLE
fix(otel): Update jaeger config

### DIFF
--- a/overlays/jaeger/jaeger-collector.Service.yaml
+++ b/overlays/jaeger/jaeger-collector.Service.yaml
@@ -15,13 +15,13 @@ spec:
     protocol: TCP
     targetPort: 14267
   - name: jaeger-collector-http
-    port: 14268
+    port: 4321
     protocol: TCP
-    targetPort: 14268
+    targetPort: 4321
   - name: jaeger-collector-grpc
-    port: 14250
+    port: 4320
     protocol: TCP
-    targetPort: 14250
+    targetPort: 4320
   selector:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/overlays/jaeger/jaeger.Deployment.yaml
+++ b/overlays/jaeger/jaeger.Deployment.yaml
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
             - containerPort: 4320
               protocol: TCP
-            - containerPort: 4320
+            - containerPort: 4321
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/overlays/jaeger/jaeger.Deployment.yaml
+++ b/overlays/jaeger/jaeger.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
         containers:
         - name: jaeger
           image: index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:3b7d972994ba6ae3b58575db3249478e2d9393e8b7f1d5c952523aaf0fdd10cf
-          args: ["--memory.max-traces=20000"]
+          args: ["--memory.max-traces=20000", "--sampling.strategies-file=/etc/jaeger/sampling_strategies.json", "--collector.otlp.enabled"]
           ports:
             - containerPort: 5775
               protocol: UDP
@@ -44,6 +44,10 @@ spec:
             - containerPort: 16686
               protocol: TCP
             - containerPort: 14250
+              protocol: TCP
+            - containerPort: 4320
+              protocol: TCP
+            - containerPort: 4320
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/overlays/jaeger/otel-collector.Deployment.yaml
+++ b/overlays/jaeger/otel-collector.Deployment.yaml
@@ -13,3 +13,5 @@ spec:
           env:
             - name: JAEGER_HOST
               value: jaeger-collector
+            - name: JAEGER_OTLP_GRPC_PORT
+              value: 4320

--- a/overlays/jaeger/otel-collector.Deployment.yaml
+++ b/overlays/jaeger/otel-collector.Deployment.yaml
@@ -15,3 +15,5 @@ spec:
               value: jaeger-collector
             - name: JAEGER_OTLP_GRPC_PORT
               value: 4320
+            - name: JAEGER_OTLP_HTTP_PORT
+              value: 4321


### PR DESCRIPTION
### Description

<!-- description here -->
Resolves [REL-171](https://linear.app/sourcegraph/issue/REL-171/cve-2024-36129-deploy-sourcegraph) for this repo

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [x] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) change: https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/153
- [x] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/1063
- [ ] All images have a valid tag and SHA256 sum
- [x] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Manual testing
