### PR TITLE
feat(rel): add step to release to update main with latest version

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -397,3 +397,77 @@ promoteToPublic:
           cat << EOF | buildkite-agent annotate --style info
           Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/deploy-sourcegraph/tree/{{version}}).
           EOF
+
+      - name: "update main with latest version"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+          echo "Checking out origin/main"
+          git fetch origin "${branch}"
+          git switch main
+          echo "Creating branch origin/${branch}"
+          git switch -c "${branch}"
+
+      - name: "sg ops (base)"
+        cmd: |
+          sg ops update-images \
+            --kind k8s \
+            --registry index.docker.io/sourcegraph \
+            --docker-username=$DOCKER_USERNAME \
+            --docker-password=$DOCKER_PASSWORD \
+            --pin-tag {{inputs.server.tag}} \
+            base/
+
+      - name: "sg ops (overlays)"
+        cmd: |
+          folders=$(find overlays -maxdepth 1 -type d \! -name "low-resource")
+
+          for path in $folders; do
+            echo "updating ${path}"
+            sg ops update-images \
+              --kind k8s \
+              --registry index.docker.io/sourcegraph \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              ${path}/
+          done
+
+      - name: "sg ops (configure)"
+        cmd: |
+          folders=$(find configure -maxdepth 1 -type d )
+
+          for path in $folders; do
+            echo "updating ${path}"
+            sg ops update-images \
+              --kind k8s \
+              --registry index.docker.io/sourcegraph \
+              --docker-username=$DOCKER_USERNAME \
+              --docker-password=$DOCKER_PASSWORD \
+              --pin-tag {{inputs.server.tag}} \
+              ${path}/
+          done
+      - name: "git:commit"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}-update-main"
+          find . -name "*.yaml" | xargs git add
+          find . -name "*.yml" | xargs git add
+
+          # Careful with the quoting for the config, using double quotes will lead
+          # to the shell dropping out all quotes from the json, leading to failed
+          # parsing.
+          git commit -am 'prep update main: {{version}}' -m 'update main with latest release'
+          git push origin "${branch}"
+
+      - name: "github:pr"
+        cmd: |
+          set -eu
+          internal_branch="promote/release-{{version}}-update-main"
+          gh pr create \
+            --fill \
+            --draft \
+            --base "$internal_branch" \
+            --title "Update main: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".


### PR DESCRIPTION
### Description

Add step to build process that creates a PR to update `main` with the latest release version.


> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [NA] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [NA] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [NA] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [NA] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [NA] All images have a valid tag and SHA256 sum
- [NA] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

Release process CI

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
