### PR TITLE
fix: jaeger port on 4317

### DIFF
--- a/overlays/jaeger/jaeger-collector.Service.yaml
+++ b/overlays/jaeger/jaeger-collector.Service.yaml
@@ -19,9 +19,9 @@ spec:
     protocol: TCP
     targetPort: 4321
   - name: jaeger-collector-grpc
-    port: 4320
+    port: 4317
     protocol: TCP
-    targetPort: 4320
+    targetPort: 4317
   selector:
     app.kubernetes.io/name: jaeger
     app.kubernetes.io/component: all-in-one

--- a/overlays/jaeger/jaeger.Deployment.yaml
+++ b/overlays/jaeger/jaeger.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
           protocol: TCP
         - containerPort: 14250
           protocol: TCP
-        - containerPort: 4320
+        - containerPort: 4317
           protocol: TCP
         - containerPort: 4321
           protocol: TCP

--- a/overlays/jaeger/otel-collector.Deployment.yaml
+++ b/overlays/jaeger/otel-collector.Deployment.yaml
@@ -14,6 +14,6 @@ spec:
             - name: JAEGER_HOST
               value: jaeger-collector
             - name: JAEGER_OTLP_GRPC_PORT
-              value: 4320
+              value: 4317
             - name: JAEGER_OTLP_HTTP_PORT
               value: 4321


### PR DESCRIPTION
### Description

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [ ] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [ ] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
