### PR TITLE
Clarify comments about KUBERNETES_RUN_AS_USER and KUBERNETES_RUN_AS_GROUP

### DIFF
--- a/configure/executors/k8s/executor.ConfigMap.yaml
+++ b/configure/executors/k8s/executor.ConfigMap.yaml
@@ -24,6 +24,11 @@ data:
   # Either set this or EXECUTOR_QUEUE_NAME.
   EXECUTOR_QUEUE_NAMES: "batches,codeintel"
   EXECUTOR_KUBERNETES_RESOURCE_REQUEST_MEMORY: "5Gi"
-#  KUBERNETES_RUN_AS_USER: "-1"
-#  KUBERNETES_RUN_AS_GROUP: "-1"
+  # KUBERNETES_RUN_AS_USER and KUBERNETES_RUN_AS_GROUP can be used to set
+  # the UID and GID of the Pods in which Batch Change and Code Intel Jobs run.
+  # If not set, or if set to blank, those Pods will use the UID and GID
+  # of the containers, which often defaults to `root`,
+  # violating the security restrictions of many cluster deployments.
+  KUBERNETES_RUN_AS_USER: ""
+  KUBERNETES_RUN_AS_GROUP: ""
 #  KUBERNETES_FS_GROUP: "1000"


### PR DESCRIPTION
### Description

Add clarifying comments to the `KUBERNETES_RUN_AS_USER` and `KUBERNETES_RUN_AS_ROOT` settings, and default them to blank instead of `"-1"`

Blank is the new default - `-1` is not allowed anymore.

### Test plan

Documentation/comments only.
