### PR TITLE
Update "master" branch language to "main"

### DIFF
--- a/.github/workflows/dispatch-update.yml.bk
+++ b/.github/workflows/dispatch-update.yml.bk
@@ -2,7 +2,7 @@ name: Dispatch update
 on:
   push:
     branches:
-    - master
+    - main
   workflow_dispatch:
     inputs:
       reason:

--- a/README.dev.md
+++ b/README.dev.md
@@ -7,19 +7,19 @@
   - [Open a PR](#open-a-pr)
   - [Smoke test](#smoke-test)
     - [Using the sourcegraph/deploy-k8s-helper tool](#using-the-sourcegraphdeploy-k8s-helper-tool)
-      - [Do smoke tests for `master` branch](#do-smoke-tests-for-master-branch)
-      - [Check the upgrade path from the previous release to `master`](#check-the-upgrade-path-from-the-previous-release-to-master)
+      - [Do smoke tests for `main` branch](#do-smoke-tests-for-main-branch)
+      - [Check the upgrade path from the previous release to `main`](#check-the-upgrade-path-from-the-previous-release-to-main)
     - [Manual instructions](#manual-instructions)
       - [Provision a new cluster](#provision-a-new-cluster)
-      - [Do smoke tests for `master` branch](#do-smoke-tests-for-master-branch-1)
-      - [Check the upgrade path from the previous release to `master`](#check-the-upgrade-path-from-the-previous-release-to-master-1)
+      - [Do smoke tests for `main` branch](#do-smoke-tests-for-main-branch-1)
+      - [Check the upgrade path from the previous release to `main`](#check-the-upgrade-path-from-the-previous-release-to-main-1)
   - [Minikube](#minikube)
 
 ## Docker images
 
 Refer to [deployment basics](https://about.sourcegraph.com/handbook/engineering/deployments#deployment-basics) to learn about Sourcegraph Docker images and [Renovate](https://renovatebot.com/docs/docker/), which performs most image updates.
 
-The `master` branch of this repository is configured to track the latest builds from `sourcegraph/sourgraph@main`, tagged as `insiders`. Renovate automatically performs updates for these images.
+The `main` branch of this repository is configured to track the latest builds from `sourcegraph/sourgraph@main`, tagged as `insiders`. Renovate automatically performs updates for these images.
 
 Release branches (`3.19`, etc) track specific versions instead, and updates are triggered manually for specific branches - see [cutting a release](#cutting-a-release).
 
@@ -47,20 +47,20 @@ If you want to update Docker images manually, you can update the Docker image ve
 
 ### Open a PR
 
-Wait for buildkite to pass and for your changes to be approved, then merge and check out `master`.
+Wait for buildkite to pass and for your changes to be approved, then merge and check out `main`.
 
 ### Smoke test
 
-Test what is currently checked in to master by [installing](docs/install.md) Sourcegraph on a fresh cluster.
+Test what is currently checked in to main by [installing](docs/install.md) Sourcegraph on a fresh cluster.
 
 #### Using the sourcegraph/deploy-k8s-helper tool
 
-Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8s-helper) to your machine and follow the [README](https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) to set up all the prerequisistes.
+Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8s-helper) to your machine and follow the [README](https://github.com/sourcegraph/deploy-k8s-helper/blob/main/README.md) to set up all the prerequisistes.
 
-##### Do smoke tests for `master` branch
+##### Do smoke tests for `main` branch
 
-1. Ensure that the `deploySourcegraphRoot` value in your stack configuration (see https://github.com/sourcegraph/deploy-k8s-helper/blob/master/README.md) is pointing to your deploy-sourcegraph checkout (ex: `pulumi config set deploySourcegraphRoot /Users/ggilmore/dev/go/src/github.com/sourcegraph/deploy-sourcegraph`)
-1. In your deploy-sourcegraph checkout, make sure that you're on the latest `master`
+1. Ensure that the `deploySourcegraphRoot` value in your stack configuration (see https://github.com/sourcegraph/deploy-k8s-helper/blob/main/README.md) is pointing to your deploy-sourcegraph checkout (ex: `pulumi config set deploySourcegraphRoot /Users/ggilmore/dev/go/src/github.com/sourcegraph/deploy-sourcegraph`)
+1. In your deploy-sourcegraph checkout, make sure that you're on the latest `main`
 1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout
 1. It'll take a few minutes for the cluster to be provisioned and for sourcegraph to be installed. Pulumi will show you the progresss that it's making, and will tell you when it's done.
 1. Use the instructions in [configure.md](docs/configure.md) to:
@@ -69,12 +69,12 @@ Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8
    1. Do a few test searches
 1. When you're done, run `yarn destroy` to tear the cluster down. This can take ~10 minutes.
 
-##### Check the upgrade path from the previous release to `master`
+##### Check the upgrade path from the previous release to `main`
 
 1. In your deploy-sourcegraph checkout, checkout the commit that contains the configuration for the previous release (e.g. the commit that has `2.11.x` images if you're currently trying to release `2.12.x`, etc.)
 1. Run `yarn up` in your https://github.com/sourcegraph/deploy-k8s-helper checkout
-1. Do [the same smoke tests that you did above](#Do-smoke-tests-for-master-branch)
-1. In your deploy-sourcegraph checkout, checkout the latest `master` commit again and run `yarn up` to deploy the new images. Check to see that [the same smoke tests](#Do-smoke-tests-for-master-branch) pass after the upgrade process.
+1. Do [the same smoke tests that you did above](#Do-smoke-tests-for-main-branch)
+1. In your deploy-sourcegraph checkout, checkout the latest `main` commit again and run `yarn up` to deploy the new images. Check to see that [the same smoke tests](#Do-smoke-tests-for-main-branch) pass after the upgrade process.
 1. When you're done, run `yarn destroy` to tear the cluster down.
 
 #### Manual instructions
@@ -83,9 +83,9 @@ Clone [`sourcegraph/deploy-k8s-helper`](https://github.com/sourcegraph/deploy-k8
 
 Refer to [how to deploy a test cluster](https://about.sourcegraph.com/handbook/engineering/deployments#test-clusters).
 
-##### Do smoke tests for `master` branch
+##### Do smoke tests for `main` branch
 
-1. Deploy the latest `master` to your new cluster by running through the quickstart steps in [docs/install.md](docs/install.md)
+1. Deploy the latest `main` to your new cluster by running through the quickstart steps in [docs/install.md](docs/install.md)
    - You'll need to create a GCP Storage Class named `sourcegraph` with the same `zone` that you created your cluster in (see ["Configure a storage class"](docs/configure.md#Configure-a-storage-class))
    - In order to give yourself permissions to create roles on the cluster, run: `kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $YOUR_NAME@sourcegraph.com`
 1. Use the instructions in [configure.md](docs/configure.md) to:
@@ -93,13 +93,13 @@ Refer to [how to deploy a test cluster](https://about.sourcegraph.com/handbook/e
    1. Enable a language extension (e.g. [Go](https://sourcegraph.com/extensions/sourcegraph/lang-go)), and test that code intelligence is working on the above repository
    1. Do a couple test searches
 
-##### Check the upgrade path from the previous release to `master`
+##### Check the upgrade path from the previous release to `main`
 
 1. Tear down the cluster that you created above by deleting it through from the [Sourcegraph CI GCP Project](https://console.cloud.google.com/kubernetes/list?project=sourcegraph-ci&organizationId=1006954638239).
 1. Checkout the commit that contains the configuration for the previous release (e.g. the commit has `2.11.x` images if you're currently trying to release `2.12.x`, etc.)
 1. [Use the "Provision a new cluster" instructions above](#Provision-a-new-cluster) to create a new cluster.
-1. Deploy the older commit to the new cluster, and do [the same smoke tests](#Do-smoke-tests-for-master-branch) with the older version.
-1. Checkout the latest `master`, deploy the newer images to the same cluster (without tearing it down in between) by running `./kubectl-apply-all.sh`, and check to see [that the smoke test](#Do-smoke-tests-for-master-branch) passes after the upgrade process.
+1. Deploy the older commit to the new cluster, and do [the same smoke tests](#Do-smoke-tests-for-main-branch) with the older version.
+1. Checkout the latest `main`, deploy the newer images to the same cluster (without tearing it down in between) by running `./kubectl-apply-all.sh`, and check to see [that the smoke test](#Do-smoke-tests-for-main-branch) passes after the upgrade process.
 
 ### Minikube
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sourcegraph on Kubernetes
 
-[![sourcegraph: search](https://img.shields.io/badge/sourcegraph-search-brightgreen.svg)](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph) [![master build status](https://badge.buildkite.com/018ed23ed79d7297e7dd109b745597c58d875323fb06e81786.svg?branch=master)](https://buildkite.com/sourcegraph/deploy-sourcegraph)
+[![sourcegraph: search](https://img.shields.io/badge/sourcegraph-search-brightgreen.svg)](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph) [![main build status](https://badge.buildkite.com/018ed23ed79d7297e7dd109b745597c58d875323fb06e81786.svg?branch=main)](https://buildkite.com/sourcegraph/deploy-sourcegraph)
 
 ## Important Notice
 
@@ -20,7 +20,7 @@ updating, and maintaining a Sourcegraph cluster.
 
 > IMPORTANT: When upgrading Sourcegraph, please check [upgrading docs](https://docs.sourcegraph.com/admin/updates/kubernetes) to check if any manual migrations are necessary.
 >
-> The `master` branch tracks development. Use the branch of this repository corresponding to the
+> The `main` branch tracks development. Use the branch of this repository corresponding to the
 > version of Sourcegraph you wish to deploy, e.g. `git checkout 3.19`.
 
 For product and [pricing](https://about.sourcegraph.com/pricing/) information, visit

--- a/base/cadvisor/README.md
+++ b/base/cadvisor/README.md
@@ -4,7 +4,7 @@
 
 cAdvisor is part of the default Sourcegraph cluster installation, and deployed as a [Kubernetes DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). This setup is based on the [official cAdvisor Kubernetes Daemonset configuration](https://github.com/google/cadvisor/tree/master/deploy/kubernetes). We use our own cAdvisor deployment over the built-in metrics exported by Kubernetes because the latter is often outdated and needs to be kept in sync with our [Docker-Compose deployments](https://docs.sourcegraph.com/admin/install/docker-compose). This setup allows us to have standard dashboards across all Sourcegraph deployments.
 
-Note that the `sourcegraph/cadvisor` Docker images come with a set of default flags to help reduce memory usage and load on Prometheus - see [our Dockerfile](https://github.com/sourcegraph/sourcegraph/blob/master/docker-images/cadvisor/Dockerfile) for more details.
+Note that the `sourcegraph/cadvisor` Docker images come with a set of default flags to help reduce memory usage and load on Prometheus - see [our entrypoint script](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/docker-images/cadvisor/entrypoint.sh) for more details.
 
 ## Namespaces
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "prHourlyLimit": 5,
   "masterIssue": true,
   "pinDigests": true,
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "kubernetes": {
     "fileMatch": ["(^|/)[^/]*\\.yaml$"]
   },


### PR DESCRIPTION
### Description

This repo switched from "master" to "main" some time ago, but the "master" branch was still being referred to.

### Test plan

Documentation/comments. Make sure CI passes.