### PR TITLE
add gitserver startup probe

### DIFF
--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -37,6 +37,14 @@ spec:
           value: http://$(OTEL_AGENT_HOST):4317
         image: index.docker.io/sourcegraph/gitserver:5.11.0@sha256:f7c4725afd1b27448472edca8b863983d095777e416bcf290f0611927c3be587
         terminationMessagePolicy: FallbackToLogsOnError
+        # Temporary: when migrating from repo names to repo IDs on disk,
+        # gitserver can take a little while to start up. To avoid killing the
+        # pod because of a failed liveness probe, we give it 2 minutes to start up.
+        startupProbe:
+          tcpSocket:
+            port: rpc
+          failureThreshold: 120
+          periodSeconds: 1
         livenessProbe:
           initialDelaySeconds: 5
           tcpSocket:


### PR DESCRIPTION
### Description

This adds a startup probe to gitserver so that it's not immediately killed while it's starting up and migrating the on-disk format for repos.

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [x] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [x] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [x] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change: https://github.com/sourcegraph/deploy-sourcegraph-k8s/pull/249
- [ ] ~Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:~ N/A
- [x] All images have a valid tag and SHA256 sum
- [x] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

Passed linters, ran it locally, plan to exercise it when we deploy to s2 and dotcom.
