### PR TITLE
Chore: Fix deployment types in telemetry

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -105,7 +105,7 @@ spec:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_AGENT_HOST):4317
         - name: DEPLOY_TYPE
-          value: "LegacyKustomize"
+          value: "legacy-kustomize"
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -104,6 +104,8 @@ spec:
               fieldPath: status.hostIP
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_AGENT_HOST):4317
+        - name: DEPLOY
+          value: "LegacyKustomize"
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: status.hostIP
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://$(OTEL_AGENT_HOST):4317
-        - name: DEPLOY
+        - name: DEPLOY_TYPE
           value: "LegacyKustomize"
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:


### PR DESCRIPTION
### Description

Linear issue [REL-812: Update deployment types](https://linear.app/sourcegraph/issue/REL-812/update-deployment-types)

Instances with deployment type "Kubernetes" are too vague to be useful in telemetry. Setting this now, so that we can start identifying these usefully in Telemetry as customers upgrade their legacy Kustomize instances >= 6.2.0

<!-- description here -->

> NOTE:

### Checklist

<!--
  Kubernetes and Docker Compose MUST be kept in sync. You should not merge a change here
  without a corresponding change in the other repository, unless it truly is specific to
  this repository. If uneeded, add link or explanation of why it is not needed here.
-->

- [ ] [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) updated
- [ ] [K8s Upgrade notes updated](https://github.com/sourcegraph/sourcegraph/blob/main/doc/admin/updates/kubernetes.md)
- [x] Sister [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] Sister [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) change:
- [ ] All images have a valid tag and SHA256 sum
- [x] I acknowledge that [deploy-sourcegraph-k8s](https://github.com/sourcegraph/deploy-sourcegraph-k8s) is now the preferred Kubernetes deployment repository

### Test plan

Test in Looker

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
